### PR TITLE
Update esptool and crosstool-ng-xtensa

### DIFF
--- a/pkgs/crosstool-ng-xtensa/default.nix
+++ b/pkgs/crosstool-ng-xtensa/default.nix
@@ -7,15 +7,15 @@ stdenv.mkDerivation rec {
   name = "crosstool-ng-xtensa";
 
   src = fetchFromGitHub {
-    owner = "espressif";
+    owner = "jcmvbkbc";
     repo = "crosstool-NG";
-    rev = "6c4433a51e4f2f2f9d9d4a13e75cd951acdfa80c";
-    sha256 = "03qg9vb0mf10nfslggmb7lc426l0gxqhfyvbadh86x41n2j6ddg6";
+    rev = "37b07f6fbea2e5d23434f7e91614528f839db056";
+    sha256 = "1rnxdnn7754s65538hmf5kh7h8j56m6ncppahfpwj327sjg8jpkb";
   };
 
   mforce-l32_patch = fetchurl {
     url = "https://github.com/jcmvbkbc/gcc-xtensa/commit/6b0c9f92fb8e11c6be098febb4f502f6af37cd35.patch";
-    sha256 = "0nx1vahlq71vr08c8g1s3w5kka19wss0l3i38ma4kxa2sc0jk856";
+    sha256 = "1cfdh7jvgg66x4xfbr1zsx7bgrcmj7y81l2wknfc7shdf69ybfax";
   };
 
   nativeBuildInputs = [

--- a/pkgs/esptool/default.nix
+++ b/pkgs/esptool/default.nix
@@ -1,30 +1,20 @@
-{ stdenv, fetchurl, fetchFromGitHub, makeWrapper, zip, python35Packages }:
+{ stdenv, fetchurl, fetchFromGitHub, makeWrapper, zip, python3Packages }:
 
-with python35Packages;
-let
-  pyaes = buildPythonPackage rec {
-    name = "pyaes-${version}";
-    version = "1.6.1";
-
-    src = fetchurl {
-      url = "mirror://pypi/p/pyaes/${name}.tar.gz";
-      sha256 = "13vdaff15k0jyfcss4b4xvfgm8xyv0nrbyw5n1qc7lrqbi0b3h82";
-    };
-  };
-in buildPythonApplication rec {
+with python3Packages;
+buildPythonApplication rec {
   name = "esptool-${version}";
-  version = "2.3.1";
+  version = "2.8";
 
   src = fetchFromGitHub {
     owner = "espressif";
     repo = "esptool";
     rev = "v${version}";
-    sha256 = "0gwnl6z5s2ax07l3n38h9hdyz71pn8lzn4fybcwyrii0bj2kapvc";
+    sha256 = "01g8r449kllsmvwxzxgm243c9p7kpj5b9bkrh569zcgg9k2s0xa0";
   };
 
   buildInputs = [ makeWrapper zip pyserial ];
   propagatedBuildInputs = [ pyserial pyaes ecdsa ];
-  
+
   doCheck = false;
 
   meta = with stdenv.lib; {


### PR DESCRIPTION
- crosstool-NG is updated to same version used by `esp-open-rtos`.
- esptool 2.7 is part of the `nixpkgs` so maybe it could be removed from here, but lets keep it for now I guess.
