### PR TITLE
convert default.nix to overlay.nix, add shell-esp-open-rtos.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,1 @@
-self: super:
-
-let
-  callPackage = super.callPackage;
-in {
-  esptool = callPackage ./pkgs/esptool {};
-
-  crosstool-ng-xtensa = callPackage ./pkgs/crosstool-ng-xtensa {};
-  gcc-xtensa-lx106-elf = callPackage ./pkgs/gcc-xtensa-lx106-elf {};
-  gcc-xtensa-esp32-elf = callPackage ./pkgs/gcc-xtensa-esp32-elf {};
-}
+import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,11 @@
+self: super:
+let
+  callPackage = super.callPackage;
+in
+{
+  esptool = callPackage ./pkgs/esptool {};
+
+  crosstool-ng-xtensa = callPackage ./pkgs/crosstool-ng-xtensa {};
+  gcc-xtensa-lx106-elf = callPackage ./pkgs/gcc-xtensa-lx106-elf {};
+  gcc-xtensa-esp32-elf = callPackage ./pkgs/gcc-xtensa-esp32-elf {};
+}

--- a/shell-esp-open-rtos.nix
+++ b/shell-esp-open-rtos.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import ./default.nix {} }:
+
+pkgs.stdenv.mkDerivation {
+  name = "esp-open-rtos-env";
+  buildInputs = with pkgs; [
+    (python37.withPackages (ppkgs: with ppkgs; [ pyserial ]))
+    gcc-xtensa-lx106-elf
+    esptool
+  ];
+  shellHook = ''
+  '';
+}

--- a/shell-esp32.nix
+++ b/shell-esp32.nix
@@ -1,9 +1,9 @@
-with import <nixpkgs> {};
+{ pkgs ? import ./default.nix {} }:
 
-stdenv.mkDerivation {
+pkgs.stdenv.mkDerivation {
   name = "esp-idf-env";
 
-  buildInputs = [
+  buildInputs = with pkgs; [
     gcc-xtensa-esp32-elf
 
     git


### PR DESCRIPTION
Easier to use, `shell-esp-open-rtos.nix` allows to enter `esp-open-rtos` like shell for building ESP8266 projects.