### PR TITLE
Add ESP32S2 toolchain and update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1636377693,
-        "narHash": "sha256-mxnUQZEA361xcupT9RIEcWrNer/+Ik/pbRMDmdRr8gQ=",
+        "lastModified": 1651369430,
+        "narHash": "sha256-d86uUm0s11exU9zLo2K1AwtJQJDKubFpoF0Iw767uT4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c11d08f02390aab49e7c22e6d0ea9b176394d961",
+        "rev": "b283b64580d1872333a99af2b4cef91bb84580cf",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,7 @@
 
       devShells = {
         esp32c3-idf = import ./shells/esp32c3-idf.nix { inherit pkgs; };
+        esp32s2-idf = import ./shells/esp32s2-idf.nix { inherit pkgs; };
         esp32-idf = import ./shells/esp32-idf.nix { inherit pkgs; };
         esp8266 = import ./shells/esp8266.nix { inherit pkgs; };
       };

--- a/overlay.nix
+++ b/overlay.nix
@@ -4,13 +4,13 @@ let
   mach-nix-src = prev.fetchFromGitHub {
     owner = "DavHau";
     repo = "mach-nix";
-    rev = "98d001727542bb6142d0ab554fc30bd591b07c73";
-    hash = "sha256-SXrwF/KPz8McBN8kN+HTfGphE1hiRSr1mtXSVjPJr8o=";
+    rev = "refs/tags/3.4.0";
+    hash = "sha256-CJDg/RpZdUVyI3QIAXUqIoYDl7VkxFtNE4JWih0ucKc=";
   };
 
   mach-nix = import mach-nix-src {
-    pypiDataRev = "2385b06414a8406732bb8c0de86b20d17ca8c19d";
-    pypiDataSha256 = "sha256:1hixh41l3f232mgwmzsljdbyvyc0sdhvl8ph5s3f8cqbw2m4yny1";
+    pypiDataRev = "f1b18354f73e8805de32e635be0fe86c9fb8eb84";
+    pypiDataSha256 = "sha256:0vmia5hlv31v99krdkp83kyg1aa76jh8896wa3cafh9q0hsry40q";
     pkgs = final;
   };
 in

--- a/overlay.nix
+++ b/overlay.nix
@@ -17,6 +17,7 @@ in
 {
   # ESP32C3
   gcc-riscv32-esp32c3-elf-bin = prev.callPackage ./pkgs/esp32c3-toolchain-bin.nix { };
+  gcc-riscv32-esp32s2-elf-bin = prev.callPackage ./pkgs/esp32s2-toolchain-bin.nix { };
   # ESP32
   gcc-xtensa-esp32-elf-bin = prev.callPackage ./pkgs/esp32-toolchain-bin.nix { };
   openocd-esp32-bin = prev.callPackage ./pkgs/openocd-esp32-bin.nix { };

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,6 +1,6 @@
 # When updating to a newer version, check if the version of `esp32-toolchain-bin.nix` also needs to be updated.
-{ rev ? "v4.3.1"
-, sha256 ? "sha256-+SMdnIBSCdHy+MDbInl/aXJuXOf9seJbQ3u4mN+qFP4="
+{ rev ? "v4.4.1"
+, sha256 ? "sha256-4dAGcJN5JVV9ywCOuhMbdTvlJSCrJdlMV6wW06xcrys="
 , stdenv
 , lib
 , fetchFromGitHub

--- a/pkgs/esp32s2-toolchain-bin.nix
+++ b/pkgs/esp32s2-toolchain-bin.nix
@@ -1,0 +1,51 @@
+# This version needs to be compatible with the version of ESP-IDF specified in `esp-idf/default.nix`.
+{ version ? "2021r1"
+, hash ? "sha256-sSe6zP5pSe5+rz0Hgup3J1CpuOJzKxbOa8ydzZH3IJo="
+, stdenv
+, lib
+, fetchurl
+, makeWrapper
+, buildFHSUserEnv
+}:
+
+let
+  fhsEnv = buildFHSUserEnv {
+    name = "esp32s2-toolchain-env";
+    targetPkgs = pkgs: with pkgs; [ zlib ];
+    runScript = "";
+  };
+in
+
+assert stdenv.system == "x86_64-linux";
+
+stdenv.mkDerivation rec {
+  pname = "esp32s2-toolchain";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/espressif/crosstool-NG/releases/download/esp-${version}/xtensa-esp32s2-elf-gcc8_4_0-esp-${version}-linux-amd64.tar.gz";
+    inherit hash;
+  };
+
+  buildInputs = [ makeWrapper ];
+
+  phases = [ "unpackPhase" "installPhase" ];
+
+  installPhase = ''
+    cp -r . $out
+    for FILE in $(ls $out/bin); do
+      FILE_PATH="$out/bin/$FILE"
+      if [[ -x $FILE_PATH ]]; then
+        mv $FILE_PATH $FILE_PATH-unwrapped
+        makeWrapper ${fhsEnv}/bin/esp32s2-toolchain-env $FILE_PATH --add-flags "$FILE_PATH-unwrapped"
+      fi
+    done
+  '';
+
+  meta = with lib; {
+    description = "ESP32S2 compiler toolchain";
+    homepage = "https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html";
+    license = licenses.gpl3;
+  };
+}
+

--- a/pkgs/esp32s2-toolchain-bin.nix
+++ b/pkgs/esp32s2-toolchain-bin.nix
@@ -1,6 +1,6 @@
 # This version needs to be compatible with the version of ESP-IDF specified in `esp-idf/default.nix`.
-{ version ? "2021r1"
-, hash ? "sha256-sSe6zP5pSe5+rz0Hgup3J1CpuOJzKxbOa8ydzZH3IJo="
+{ version ? "2021r2-patch3"
+, hash ? "sha256-oyRRqO3BEEuDzZlxF45hgm6VfX25rZ+BeYqJaf1alU4="
 , stdenv
 , lib
 , fetchurl

--- a/shells/esp32s2-idf.nix
+++ b/shells/esp32s2-idf.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf";
+
+  buildInputs = with pkgs; [
+    gcc-riscv32-esp32s2-elf-bin
+    openocd-esp32-bin
+    esp-idf
+    esptool
+
+    # Tools required to use ESP-IDF.
+    git
+    wget
+    gnumake
+
+    flex
+    bison
+    gperf
+    pkgconfig
+
+    cmake
+    ninja
+
+    ncurses5
+  ];
+}


### PR DESCRIPTION
This adds a devshell for the ESP32S2 toochain and updates some stuff:
- the flake itself
- mach-nix and the pypi data source
- esp-edf to 4.4.1
- esp-toolchain to 2021r2-patch3