### PR TITLE
Add esp32s2, update to v4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The easiest way to get started is to run one of these commands to get a developm
 If you're not using Nix 2.4+ or prefer not to need to enable flakes, you can clone the repo and use one of:
 
 - `nix-shell shells/esp32c3-idf.nix`
+- `nix-shell shells/esp32s2-idf.nix`
 - `nix-shell shells/esp32-idf.nix`
 - `nix-shell shells/esp8266.nix`
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1634851050,
-        "narHash": "sha256-N83GlSGPJJdcqhUxSCS/WwW5pksYf3VP1M13cDRTSVA=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c91f3de5adaf1de973b797ef7485e441a65b8935",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         inherit (pkgs)
           gcc-riscv32-esp32c3-elf-bin
           gcc-xtensa-esp32-elf-bin
+          gcc-xtensa-esp32s2-elf-bin
           openocd-esp32-bin
           esp-idf
 
@@ -27,6 +28,7 @@
 
       devShells = {
         esp32c3-idf = import ./shells/esp32c3-idf.nix { inherit pkgs; };
+        esp32s2-idf = import ./shells/esp32s2-idf.nix { inherit pkgs; };
         esp32-idf = import ./shells/esp32-idf.nix { inherit pkgs; };
         esp8266 = import ./shells/esp8266.nix { inherit pkgs; };
       };

--- a/overlay.nix
+++ b/overlay.nix
@@ -9,14 +9,16 @@ let
   };
 
   mach-nix = import mach-nix-src {
-    pypiDataRev = "2385b06414a8406732bb8c0de86b20d17ca8c19d";
-    pypiDataSha256 = "sha256:1hixh41l3f232mgwmzsljdbyvyc0sdhvl8ph5s3f8cqbw2m4yny1";
+    pypiDataRev = "1d17587404960e2e9fd0fd7e514b0bbc52abcdfd";
+    pypiDataSha256 = "sha256:078i0af4s1la5cafq958wfk8as711qlf81ngrg0xq0wys7ainig1";
     pkgs = final;
   };
 in
 {
   # ESP32C3
   gcc-riscv32-esp32c3-elf-bin = prev.callPackage ./pkgs/esp32c3-toolchain-bin.nix { };
+  # ESP32S2
+  gcc-xtensa-esp32s2-elf-bin = prev.callPackage ./pkgs/esp32s2-toolchain-bin.nix { };
   # ESP32
   gcc-xtensa-esp32-elf-bin = prev.callPackage ./pkgs/esp32-toolchain-bin.nix { };
   openocd-esp32-bin = prev.callPackage ./pkgs/openocd-esp32-bin.nix { };

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,6 +1,6 @@
 # When updating to a newer version, check if the version of `esp32-toolchain-bin.nix` also needs to be updated.
-{ rev ? "v4.3.1"
-, sha256 ? "sha256-+SMdnIBSCdHy+MDbInl/aXJuXOf9seJbQ3u4mN+qFP4="
+{ rev ? "v4.4.1"
+, sha256 ? "sha256-4dAGcJN5JVV9ywCOuhMbdTvlJSCrJdlMV6wW06xcrys="
 , stdenv
 , lib
 , fetchFromGitHub

--- a/pkgs/esp32-toolchain-bin.nix
+++ b/pkgs/esp32-toolchain-bin.nix
@@ -1,6 +1,6 @@
 # This version needs to be compatible with the version of ESP-IDF specified in `esp-idf/default.nix`.
-{ version ? "2021r1"
-, hash ? "sha256-RKC0Z7nSt1mrSLLyeu1oRYHzPJbihCmSeBxOBFmSxbA="
+{ version ? "2021r2-patch3"
+, hash ? "sha256-nt0ed2J2iPQ1Vhki0UKZ9qACG6H2/2fkcuEQhpWmnlM="
 , stdenv
 , lib
 , fetchurl

--- a/pkgs/esp32s2-toolchain-bin.nix
+++ b/pkgs/esp32s2-toolchain-bin.nix
@@ -1,6 +1,6 @@
 # This version needs to be compatible with the version of ESP-IDF specified in `esp-idf/default.nix`.
 { version ? "2021r2-patch3"
-, hash ? "sha256-F5y61Xl5CtNeD0FKGNkAF8DxWMOXAiQRqOmGfbIXTxU="
+, hash ? "sha256-oyRRqO3BEEuDzZlxF45hgm6VfX25rZ+BeYqJaf1alU4="
 , stdenv
 , lib
 , fetchurl
@@ -10,7 +10,7 @@
 
 let
   fhsEnv = buildFHSUserEnv {
-    name = "esp32c3-toolchain-env";
+    name = "esp32s2-toolchain-env";
     targetPkgs = pkgs: with pkgs; [ zlib ];
     runScript = "";
   };
@@ -19,11 +19,11 @@ in
 assert stdenv.system == "x86_64-linux";
 
 stdenv.mkDerivation rec {
-  pname = "esp32c3-toolchain";
+  pname = "esp32s2-toolchain";
   inherit version;
 
   src = fetchurl {
-    url = "https://github.com/espressif/crosstool-NG/releases/download/esp-${version}/riscv32-esp-elf-gcc8_4_0-esp-${version}-linux-amd64.tar.gz";
+    url = "https://github.com/espressif/crosstool-NG/releases/download/esp-${version}/xtensa-esp32s2-elf-gcc8_4_0-esp-${version}-linux-amd64.tar.gz";
     inherit hash;
   };
 
@@ -37,13 +37,13 @@ stdenv.mkDerivation rec {
       FILE_PATH="$out/bin/$FILE"
       if [[ -x $FILE_PATH ]]; then
         mv $FILE_PATH $FILE_PATH-unwrapped
-        makeWrapper ${fhsEnv}/bin/esp32c3-toolchain-env $FILE_PATH --add-flags "$FILE_PATH-unwrapped"
+        makeWrapper ${fhsEnv}/bin/esp32s2-toolchain-env $FILE_PATH --add-flags "$FILE_PATH-unwrapped"
       fi
     done
   '';
 
   meta = with lib; {
-    description = "ESP32-C3 compiler toolchain";
+    description = "ESP32-S2 compiler toolchain";
     homepage = "https://docs.espressif.com/projects/esp-idf/en/stable/get-started/linux-setup.html";
     license = licenses.gpl3;
   };

--- a/pkgs/openocd-esp32-bin.nix
+++ b/pkgs/openocd-esp32-bin.nix
@@ -9,11 +9,11 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "openocd";
-  version = "0.10.0-esp32-20210902";
+  version = "0.11.0-esp32-20220706";
 
   src = fetchurl {
-    url = "https://github.com/espressif/openocd-esp32/releases/download/v${version}/openocd-esp32-linux64-${version}.tar.gz";
-    hash = "sha256-vXNkuL9PoD7rusf4q6hjICnDSUbuZ9RRwCGCqui8OOA=";
+    url = "https://github.com/espressif/openocd-esp32/releases/download/v${version}/openocd-esp32-linux-amd64-${version}.tar.gz";
+    hash = "sha256-JvHxjdk+twoTIDhI0/scwuDeH9Z0nH3XcbLehwlzWu0=";
   };
 
   buildInputs = [ makeWrapper ];

--- a/shells/esp32s2-idf.nix
+++ b/shells/esp32s2-idf.nix
@@ -1,0 +1,27 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf";
+
+  buildInputs = with pkgs; [
+    gcc-xtensa-esp32s2-elf-bin
+    openocd-esp32-bin
+    esp-idf
+    esptool
+
+    # Tools required to use ESP-IDF.
+    git
+    wget
+    gnumake
+
+    flex
+    bison
+    gperf
+    pkgconfig
+
+    cmake
+    ninja
+
+    ncurses5
+  ];
+}


### PR DESCRIPTION
This PR adds a shell env for the ESP32-S2, and updates ESP-IDF for all configurations to the latest version 4.4.1, and OpenOCD to version 11.