### PR TITLE
ESP-IDF v5.1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,8 @@
           esp-idf-esp32c3
           esp-idf-esp32s2
           esp-idf-esp32s3
+          esp-idf-esp32c6
+          esp-idf-esp32h2
           gcc-xtensa-lx106-elf-bin;
       };
 
@@ -28,6 +30,8 @@
         esp32c3-idf = import ./shells/esp32c3-idf.nix { inherit pkgs; };
         esp32s2-idf = import ./shells/esp32s2-idf.nix { inherit pkgs; };
         esp32s3-idf = import ./shells/esp32s3-idf.nix { inherit pkgs; };
+        esp32c6-idf = import ./shells/esp32c6-idf.nix { inherit pkgs; };
+        esp32h2-idf = import ./shells/esp32h2-idf.nix { inherit pkgs; };
         esp8266 = import ./shells/esp8266.nix { inherit pkgs; };
       };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -11,13 +11,15 @@ rec {
     ];
   };
 
-  esp-idf-esp32c3 = esp-idf-full.override {
+  esp-idf-riscv = esp-idf-full.override {
     toolsToInclude = [
       "riscv32-esp-elf"
       "openocd-esp32"
       "riscv32-esp-elf-gdb"
     ];
   };
+
+  esp-idf-esp32c3 = esp-idf-riscv;
 
   esp-idf-esp32s2 = esp-idf-full.override {
     toolsToInclude = [
@@ -36,6 +38,10 @@ rec {
       "xtensa-esp-elf-gdb"
     ];
   };
+
+  esp-idf-esp32c6 = esp-idf-riscv;
+
+  esp-idf-esp32h2 = esp-idf-riscv;
 
   # ESP8266
   gcc-xtensa-lx106-elf-bin = prev.callPackage ./pkgs/esp8266-toolchain-bin.nix { };

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,12 +1,12 @@
-{ rev ? "v5.0.2"
-, sha256 ? "sha256-dlmtTjoz4qQdFG229v9bIHKpYBzjM44fv+XhdDBu2Os="
+{ rev ? "v5.1"
+, sha256 ? "sha256-IEa9R9VCWvbRjZFRPb2Qq2Qw1RFxsnVALFVgQlBCXMw="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"
     "xtensa-esp32-elf"
     "xtensa-esp32s2-elf"
     "xtensa-esp32s3-elf"
-    "xtensa-clang"
+    "esp-clang"
     "riscv32-esp-elf"
     "esp32ulp-elf"
     "openocd-esp32"
@@ -63,15 +63,15 @@ let
           setuptools
           click
           pyserial
-          future
           cryptography
           pyparsing
           pyelftools
           idf-component-manager
           esp-coredump
           esptool
-
-          kconfiglib
+          esp-idf-kconfig
+          esp-idf-monitor
+          esp-idf-size
 
           freertos_gdb
         ]));

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -1,6 +1,6 @@
 # Versions based on
-# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.0.txt
-# on 2023-06-30.
+# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.1.txt
+# on 2023-07-05.
 
 { stdenv
 , lib
@@ -14,20 +14,20 @@ with pythonPackages;
 rec {
   idf-component-manager = buildPythonPackage rec {
     pname = "idf-component-manager";
-    version = "1.3.0";
+    version = "1.3.2";
 
     src = fetchFromGitHub {
       owner = "espressif";
       repo = pname;
       rev = "v${version}";
-      sha256 = "sha256-J/Sj6YRb/kPx2lPw/1b3YQExhEJK8z2zzqiuFv0Zuac=";
+      sha256 = "sha256-rHZHlvRKMZvvjf3S+nU2lCDXt0Ll4Ek04rdhtfIQ1R0=";
     };
 
     # For some reason, this 404s.
     /*
       src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-1bozmQ4Eb5zL4rtNHSFjEynfObUkYlid1PgMDVmRkwY=";
+      sha256 = "sha256-12ozmQ4Eb5zL4rtNHSFjEynfObUkYlid1PgMDVmRkwY=";
       };
     */
 
@@ -58,11 +58,11 @@ rec {
 
   esp-coredump = buildPythonPackage rec {
     pname = "esp-coredump";
-    version = "1.5.0";
+    version = "1.5.2";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-Zni9RkniGQp885h2H40U4oEOoRHF35cF9OfxWQrk4Xg=";
+      sha256 = "sha256-hQkXnGoAXCLk/PV7Y+C0hOgXGRY77zbIp2ZDC0cxfLo=";
     };
 
     doCheck = false;
@@ -80,11 +80,11 @@ rec {
 
   esptool = buildPythonPackage rec {
     pname = "esptool";
-    version = "4.5.1";
+    version = "4.6.2";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-4+tZg2Ej5ev3k+9jkxH32FZFUmSH2LHCtRFZtFUQa5o=";
+      sha256 = "sha256-VJ75Pu9C7n6UYs5aU8Ft96DHHZGz934Z7BV0mATN8wA=";
     };
 
     doCheck = false;
@@ -100,6 +100,68 @@ rec {
 
     meta = {
       homepage = "https://github.com/espressif/esptool";
+    };
+  };
+
+  esp-idf-kconfig = buildPythonPackage rec {
+    pname = "esp-idf-kconfig";
+    version = "1.1.0";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-s8ZXt6cf5w2pZSxQNIs/SODAUvHNgxyQ+onaCa7UbFA=";
+    };
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      kconfiglib
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-kconfig";
+    };
+  };
+
+  esp-idf-monitor = buildPythonPackage rec {
+    pname = "esp-idf-monitor";
+    version = "1.1.1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-c62X3ZHRShhbAFmuPc/d2keqE9T9SXYIlJTyn32LPaE=";
+    };
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      pyserial
+      esp-coredump
+      pyelftools
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-monitor";
+    };
+  };
+
+  esp-idf-size = buildPythonPackage rec {
+    pname = "esp-idf-size";
+    version = "0.3.1";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-OzthhzKGjyqDJrmJWs4LMkHz0rAwho+3Pyc2BYFK0EU=";
+    };
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      pyyaml
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-size";
     };
   };
 

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -19,7 +19,7 @@ let
     xtensa-esp32-elf = pkgs: (with pkgs; [ ]);
     xtensa-esp32s2-elf = pkgs: (with pkgs; [ ]);
     xtensa-esp32s3-elf = pkgs: (with pkgs; [ ]);
-    xtensa-clang = pkgs: (with pkgs; [ ]);
+    esp-clang = pkgs: (with pkgs; [ zlib libxml2 ]);
     riscv32-esp-elf = pkgs: (with pkgs; [ ]);
     esp32ulp-elf = pkgs: (with pkgs; [ ]);
     openocd-esp32 = pkgs: (with pkgs; [ zlib libusb1 ]);

--- a/shells/esp32c6-idf.nix
+++ b/shells/esp32c6-idf.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf-esp32c6-shell";
+
+  buildInputs = with pkgs; [
+    esp-idf-esp32c6
+  ];
+}

--- a/shells/esp32h2-idf.nix
+++ b/shells/esp32h2-idf.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf-esp32h2-shell";
+
+  buildInputs = with pkgs; [
+    esp-idf-esp32h2
+  ];
+}

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -34,7 +34,7 @@ let
     });
 
   buildsNameList = pkgs.lib.attrsets.cartesianProductOfSets {
-    target = [ "esp32" "esp32c3" "esp32s2" "esp32s3" ];
+    target = [ "esp32" "esp32c3" "esp32s2" "esp32s3" "esp32c6" "esp32h2" ];
     example = [ "get-started/hello_world" ];
   };
 


### PR DESCRIPTION
Includes ESP32-C6 and ESP32-H2 support.

Fixes #24