### PR TITLE
The dependency on lockfile has been replaced with filelock in package…

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1687977148,
-        "narHash": "sha256-gUcXiU2GgjYIc65GOIemdBJZ+lkQxuyIh7OkR9j0gCo=",
+        "lastModified": 1688859638,
+        "narHash": "sha256-GyRhX8GlTQqDWx43uBFEYEQ/WKEqDwjzABHxUCatAno=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "60a783e00517fce85c42c8c53fe0ed05ded5b2a4",
+        "rev": "d485da9d0034a72ceb9679c2ab0156c073f66b82",
         "type": "github"
       },
       "original": {

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -35,7 +35,6 @@ rec {
 
     propagatedBuildInputs = [
       cachecontrol
-      lockfile
       cffi
       click
       colorama
@@ -49,7 +48,7 @@ rec {
       schema
       six
       tqdm
-    ];
+    ] ++ cachecontrol.optional-dependencies.filecache;
 
     meta = {
       homepage = "https://github.com/espressif/idf-component-manager";


### PR DESCRIPTION
After a nix flake update there is an error when building idf-component-mananger. The dependency lockfile has been replaced by filelock for python-package cachecontrol

error: builder for '/nix/store/6arsf1hqbiawvccgylp06hda1gi3v2ga-python3.10-idf-component-manager-1.3.2.drv' failed with exit code 1;
       last 10 log lines:
       > Requirement already satisfied: requests<3 in /nix/store/p1hqnnviw7lcv21kvkhsh92s9rvni5cz-python3.10-requests-2.31.0/lib/python3.10/site-packages (from idf-component-manager==1.3.2) (2.31.0)
       > Requirement already satisfied: contextlib2>0.6.0 in /nix/store/l7rffmn5y1inwp56ff9n76i8caf8brh9-python3.10-contextlib2-21.6.0/lib/python3.10/site-packages (from idf-component-manager==1.3.2) (21.6.0)
       > Requirement already satisfied: schema in /nix/store/iczhmarn71d1523qcr82hpmjh1rq9ji3-python3.10-schema-0.7.5/lib/python3.10/site-packages (from idf-component-manager==1.3.2) (0.7.5)
       > Requirement already satisfied: requests-toolbelt in /nix/store/y41cjf3cylm41yw89x9gdizda4ym2lyv-python3.10-requests-toolbelt-0.10.1/lib/python3.10/site-packages (from idf-component-manager==1.3.2) (0.10.1)
       > Requirement already satisfied: msgpack>=0.5.2 in /nix/store/7qarxkwrfa03bjiq8b41rzbaklrvdn39-python3.10-msgpack-1.0.5/lib/python3.10/site-packages (from cachecontrol[filecache]>0.12.6->idf-component-manager==1.3.2) (1.0.5)
       > INFO: pip is looking at multiple versions of <Python from Requires-Python> to determine which version is compatible with other requirements. This could take a while.
       > INFO: pip is looking at multiple versions of idf-component-manager to determine which version is compatible with other requirements. This could take a while.
       > ERROR: Could not find a version that satisfies the requirement filelock>=3.8.0; extra == "filecache" (from cachecontrol[filecache]) (from versions: none)
       > ERROR: No matching distribution found for filelock>=3.8.0; extra == "filecache"
       >
       For full logs, run 'nix log /nix/store/6arsf1hqbiawvccgylp06hda1gi3v2ga-python3.10-idf-component-manager-1.3.2.drv'.
error: 1 dependencies of derivation '/nix/store/ywpnipqifswjdszv1jjvzi6qh2n3idka-python3-3.10.12-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/2axc1mjwy9rbgyr1azdbqrmqy5dfpr4y-esp-idf-v5.1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/dwp0h0wf9y9mvwccppwswqizw3vp4h34-esp-idf-esp32c3-shell-env.drv' failed to buil