### PR TITLE
Rename pkgconfig to pkg-config

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -26,7 +26,7 @@
 , flex
 , bison
 , gperf
-, pkgconfig
+, pkg-config
 , cmake
 , ninja
 , ncurses5
@@ -100,7 +100,7 @@ stdenv.mkDerivation rec {
     flex
     bison
     gperf
-    pkgconfig
+    pkg-config
 
     cmake
     ninja

--- a/pkgs/esp8266-rtos-sdk/esp8266-rtos-sdk.nix
+++ b/pkgs/esp8266-rtos-sdk/esp8266-rtos-sdk.nix
@@ -14,7 +14,7 @@
 , flex
 , bison
 , gperf
-, pkgconfig
+, pkg-config
 , ncurses5
 
 , cmake
@@ -81,7 +81,7 @@ stdenv.mkDerivation rec {
     flex
     bison
     gperf
-    pkgconfig
+    pkg-config
 
     cmake
     ninja


### PR DESCRIPTION
Fixes following issue:
```
         at /nix/store/g68f5abh3xhcz8xsdlfw7wkgkkcx3nwy-source/pkgs/stdenv/genern.nix:347:7:

          346|       depsHostHost                = lib.elemAt (lib.elemAt depend          347|       buildInputs                 = lib.elemAt (lib.elemAt depend             |       ^
          348|       depsTargetTarget            = lib.elemAt (lib.elemAt depend
       (stack trace truncated; use '--show-trace' to show the full trace)

       error: 'pkgconfig' has been renamed to/replaced by 'pkg-config'

```