### PR TITLE
Add esp-idf-panic-decoder python package and bump to v5.1.2 by default

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,5 +1,5 @@
-{ rev ? "v5.1"
-, sha256 ? "sha256-IEa9R9VCWvbRjZFRPb2Qq2Qw1RFxsnVALFVgQlBCXMw="
+{ rev ? "v5.1.2"
+, sha256 ? "sha256-uEf3/3NPH+E39VgQ02AbxTG7nmG5bQlhwk/WcTeAUfg="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"
@@ -72,6 +72,7 @@ let
           esp-idf-kconfig
           esp-idf-monitor
           esp-idf-size
+          esp-idf-panic-decoder
 
           freertos_gdb
         ]));

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -182,5 +182,28 @@ rec {
       homepage = "https://github.com/espressif/freertos-gdb";
     };
   };
+
+  esp-idf-panic-decoder = buildPythonPackage rec {
+    pname = "esp-idf-panic-decoder";
+    version = "0.2.0";
+
+    format = "pyproject";
+    
+    src = fetchPypi {
+      inherit version;
+      pname = "esp_idf_panic_decoder";
+      sha256 = "sha256-t1pg+L7WWVoVZ7weE/CUdMJsgRQvLEUE/GVeJpt0kKI=";
+    };
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      setuptools
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-panic-decoder";
+    };
+  };
 }
 


### PR DESCRIPTION
I recently had a bug in v5.1 and which has been fixed in the latest bug fix release, however it has a new python package dependency (https://github.com/espressif/esp-idf-panic-decoder).

This merge request add this package and bump the default esp-idf version installed from v5.1 to [v5.1.2](https://github.com/espressif/esp-idf/releases/tag/v5.1.2).

I could not find a constraints file for v5.1.2, just changing the URL doesn't work (https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.1.2.txt).