### PR TITLE
Add  esp-idf-esp32 to flake packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       packages = {
         inherit (pkgs)
           esp-idf-full
+          esp-idf-esp32
           esp-idf-esp32c3
           esp-idf-esp32s2
           esp-idf-esp32s3


### PR DESCRIPTION
I saw that the base esp-idf-esp32 package was missing from the flake package list. So I added it.