### PR TITLE
drop unused requirements from idf-component-manager, fixing #36

### DIFF
--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -38,17 +38,22 @@ rec {
       cffi
       click
       colorama
-      contextlib2
       packaging
       pyyaml
       requests
-      urllib3
       requests-file
       requests-toolbelt
       schema
       six
       tqdm
     ] ++ cachecontrol.optional-dependencies.filecache;
+
+    # setup.py says it needs these deps, but it actually doesn't. contextlib2
+    # isn't supported on some pythons and urllib3 is pinned to an old version
+    postPatch = ''
+      sed -i '/contextlib2/d' setup.py
+      sed -i '/urllib3/d' setup.py
+    '';
 
     meta = {
       homepage = "https://github.com/espressif/idf-component-manager";


### PR DESCRIPTION
fixes #36

for some reason these are listed in the idf-component-manager setup.py, but have never been used directly in a released version

contextlib2 isn't yet supported in python 3.11, so causes a build error when built with a version of nixpkgs which uses that by default, and urllib3 is pined to a version older than is in nixpkgs