### PR TITLE
bump to esp-idf 5.2.1

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -4,7 +4,7 @@ rec {
 
   esp-idf-esp32 = esp-idf-full.override {
     toolsToInclude = [
-      "xtensa-esp32-elf"
+      "xtensa-esp-elf"
       "esp32ulp-elf"
       "openocd-esp32"
       "xtensa-esp-elf-gdb"
@@ -23,7 +23,7 @@ rec {
 
   esp-idf-esp32s2 = esp-idf-full.override {
     toolsToInclude = [
-      "xtensa-esp32s2-elf"
+      "xtensa-esp-elf"
       "esp32ulp-elf"
       "openocd-esp32"
       "xtensa-esp-elf-gdb"
@@ -32,7 +32,7 @@ rec {
 
   esp-idf-esp32s3 = esp-idf-full.override {
     toolsToInclude = [
-      "xtensa-esp32s3-elf"
+      "xtensa-esp-elf"
       "esp32ulp-elf"
       "openocd-esp32"
       "xtensa-esp-elf-gdb"

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,11 +1,9 @@
-{ rev ? "v5.1.2"
-, sha256 ? "sha256-uEf3/3NPH+E39VgQ02AbxTG7nmG5bQlhwk/WcTeAUfg="
+{ rev ? "v5.2.1"
+, sha256 ? "sha256-0WwDcasG7JjRJIaZyjWTobKhZXUi4pcSHFMtTbBJE1g="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"
-    "xtensa-esp32-elf"
-    "xtensa-esp32s2-elf"
-    "xtensa-esp32s3-elf"
+    "xtensa-esp-elf"
     "esp-clang"
     "riscv32-esp-elf"
     "esp32ulp-elf"
@@ -73,6 +71,7 @@ let
           esp-idf-monitor
           esp-idf-size
           esp-idf-panic-decoder
+          pyclang
 
           freertos_gdb
 

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -1,6 +1,6 @@
 # Versions based on
-# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.1.txt
-# on 2023-07-05.
+# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.2.txt
+# on 2024-02-20.
 
 { stdenv
 , lib
@@ -209,6 +209,18 @@ rec {
     meta = {
       homepage = "https://github.com/espressif/esp-idf-panic-decoder";
     };
+  };
+
+  pyclang = buildPythonPackage rec {
+    pname = "pyclang";
+    version = "0.4.2";
+
+    src = fetchPypi {
+      inherit pname version;
+      sha256 = "sha256-vuDZ5yEhyDpCmkXoC+Gr2X5vMK5B46HnktcvBONjxXM=";
+    };
+
+    doCheck = false;
   };
 }
 

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -18,9 +18,7 @@ let
   toolFhsEnvTargetPackages = {
     xtensa-esp-elf-gdb = pkgs: (with pkgs; [ ]);
     riscv32-esp-elf-gdb = pkgs: (with pkgs; [ ]);
-    xtensa-esp32-elf = pkgs: (with pkgs; [ ]);
-    xtensa-esp32s2-elf = pkgs: (with pkgs; [ ]);
-    xtensa-esp32s3-elf = pkgs: (with pkgs; [ ]);
+    xtensa-esp-elf = pkgs: (with pkgs; [ ]);
     esp-clang = pkgs: (with pkgs; [ zlib libxml2 ]);
     riscv32-esp-elf = pkgs: (with pkgs; [ ]);
     esp32ulp-elf = pkgs: (with pkgs; [ ]);

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -89,8 +89,10 @@ let
       installPhase = let
         wrapCmd = if system == "x86_64-linux" then
         ''
-          mv $FILE_PATH $FILE_PATH-unwrapped
-          makeWrapper ${fhsEnv}/bin/${pname}-env $FILE_PATH --add-flags "$FILE_PATH-unwrapped" ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
+          [ ! -d $out/unwrapped_bin ] && mkdir $out/unwrapped_bin
+          WRAPPED_FILE_PATH="$out/unwrapped_bin/$(basename $FILE_PATH)"
+          mv $FILE_PATH $WRAPPED_FILE_PATH
+          makeWrapper ${fhsEnv}/bin/${pname}-env $FILE_PATH --add-flags $WRAPPED_FILE_PATH ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
         ''
       else
       ''wrapProgram $FILE_PATH ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}'';


### PR DESCRIPTION
This version has major changes with a compiler bump in the gcc fork from 12 to 13.

I am not able to make it pass the nix checks and fail to compile any projects because cmake fails compiler checks.

Here is what I get while trying to compile https://github.com/espressif/esp-idf/tree/v5.2.1/examples/get-started/hello_world.

```
WARNING: Python interpreter "/nix/store/spinxrzlw8c5si1k21vhzqs3xd15h18d-python3-3.11.7-env/bin/python3.11" used to start idf.py is not from installed venv "/nix/store/0zd4ppy7lhq8vknf3j0xb8h15zyhhs0a-esp-idf-v5.2.1/python-env"
Adding "set-target"'s dependency "fullclean" to list of commands with default set of options.
Executing action: fullclean
Build directory '/tmp/esp-idf/examples/get-started/hello_world/build' not found. Nothing to clean.
Executing action: set-target
Set Target to: esp32s3, new sdkconfig will be created.
Running cmake in directory /tmp/esp-idf/examples/get-started/hello_world/build
Executing "cmake -G Ninja -DPYTHON_DEPS_CHECKED=1 -DPYTHON=/nix/store/spinxrzlw8c5si1k21vhzqs3xd15h18d-python3-3.11.7-env/bin/python3.11 -DESP_PLATFORM=1 -DIDF_TARGET=esp32s3 -DCCACHE_ENABLE=0 /tmp/esp-idf/examples/get-started/hello_world"...
-- Found Git: /nix/store/za04kin80ybavb7qp577dghpax4mf82z-git-2.43.0/bin/git (found version "2.43.0")
-- git rev-parse returned 'fatal: not a git repository (or any of the parent directories): .git'
fatal: not a git repository (or any of the parent directories): .git
-- The C compiler identification is GNU 13.2.0
-- The CXX compiler identification is GNU 13.2.0
-- The ASM compiler identification is GNU
-- Found assembler: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - failed
-- Check for working C compiler: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc
-- Check for working C compiler: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc - broken
CMake Error at /nix/store/jacf2kn4dfj99c3ywbvfyg6w53xvxsfl-cmake-3.27.8/share/cmake-3.27/Modules/CMakeTestCCompiler.cmake:67 (message):
  The C compiler

    "/nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc"

  is not able to compile a simple test program.

  It fails with the following output:

    Change Dir: '/tmp/esp-idf/examples/get-started/hello_world/build/CMakeFiles/CMakeScratch/TryCompile-fjqxvP'

    Run Build Command(s): /nix/store/5lbxsj5mnz95rq5hkq7ixxb1cg96k07g-ninja-1.11.1/bin/ninja -v cmTC_fd6c1
    [1/2] /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc   -mlongcalls -o CMakeFiles/cmTC_fd6c1.dir/testCCompiler.c.obj -c /tmp/esp-idf/examples/get-started/hello_world/build/CMakeFiles/CMakeScratch/TryCompile-fjqxvP/testCCompiler.c
    [2/2] : && /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc -mlongcalls  CMakeFiles/cmTC_fd6c1.dir/testCCompiler.c.obj -o cmTC_fd6c1   && :
    FAILED: cmTC_fd6c1
    : && /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/xtensa-esp32s3-elf-gcc -mlongcalls  CMakeFiles/cmTC_fd6c1.dir/testCCompiler.c.obj -o cmTC_fd6c1   && :
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/lib/crt0.o: compiled for a big endian system and target is little endian
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: failed to merge target specific data of file /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/lib/crt0.o
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crti.o: compiled for a big endian system and target is little endian
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: failed to merge target specific data of file /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crti.o
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtbegin.o: compiled for a big endian system and target is little endian
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: failed to merge target specific data of file /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtbegin.o
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtend.o: compiled for a big endian system and target is little endian
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: failed to merge target specific data of file /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtend.o
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtn.o: compiled for a big endian system and target is little endian
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: failed to merge target specific data of file /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/crtn.o
    /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/bin/ld: cross-endian linking for /nix/store/6p0xpb8gxzp0mav0bbgr2mxmdyhsd6aq-xtensa-esp-elf-esp-idf-v5.2.1/bin/../lib/gcc/xtensa-esp-elf/13.2.0/../../../../xtensa-esp-elf/lib/crt0.o not supported
    collect2: error: ld returned 1 exit status
    ninja: build stopped: subcommand failed.





  CMake will not be able to correctly generate this project.
Call Stack (most recent call first):
  /nix/store/0zd4ppy7lhq8vknf3j0xb8h15zyhhs0a-esp-idf-v5.2.1/tools/cmake/project.cmake:506 (__project)
  CMakeLists.txt:6 (project)


-- Configuring incomplete, errors occurred!
cmake failed with exit code 1, output of the command is in the /tmp/esp-idf/examples/get-started/hello_world/build/log/idf_py_stderr_output_14913 and /tmp/esp-idf/examples/get-started/hello_world/build/log/idf_py_stdout_output_14913
```

I am not an expert in compiler toolchain, maybe someone could build upon this to fix it ?