### PR TITLE
Update ESP-IDF to v5.1.3

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,5 +1,5 @@
-{ rev ? "v5.1.2"
-, sha256 ? "sha256-uEf3/3NPH+E39VgQ02AbxTG7nmG5bQlhwk/WcTeAUfg="
+{ rev ? "v5.1.3"
+, sha256 ? "sha256-0QsIFOcSx1N15t5po3TyOaNvpzBUfKaFdsRODOBoXCI="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"


### PR DESCRIPTION
Hi.
It's a minor change but I thought it'd better if it gets updated to 5.1.3 before 5.2 is merged.
Last couple of weeks I got into quite a few issues because of the changes between 5.1.2 and 5.1.3. nothing breaking but some APIs have changed and I had to manually check them. The main idf documentation opens 5.1.3 now.

I did verify it with my projects. It seems fine with both esp32 and esp32s3