### PR TITLE
Fix openocd scripts path

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -108,6 +108,10 @@ let
             ${wrapCmd}
           fi
         done
+
+        # Fix openocd scripts path
+        mkdir $out/openocd-esp32
+        ln -s $out/share $out/openocd-esp32
       '';
 
       meta = with lib; {


### PR DESCRIPTION
In tools.json, openocd export_vars is set to `${TOOL_PATH}/openocd-esp32/share/openocd/scripts` and `${TOOL_PATH}` correspond to our $out.

Making this symlink allows openocd to find the scripts that are needed.