### PR TITLE
Fix "idf.py create-project" failures due to read-only files 

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -91,6 +91,10 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ makeWrapper ];
 
+  # Do not preserve file modes when copying templates as the nix store is read-only.
+  # create-project will fail without this.
+  patches = [ ./template-modes.patch ];
+
   propagatedBuildInputs = [
     # This is in propagatedBuildInputs so that downstream derivations will run
     # the Python setup hook and get PYTHONPATH set up correctly.

--- a/pkgs/esp-idf/template-modes.patch
+++ b/pkgs/esp-idf/template-modes.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/idf_py_actions/create_ext.py b/tools/idf_py_actions/create_ext.py
+index 6a3e632485..3e9e33bb2b 100644
+--- a/tools/idf_py_actions/create_ext.py
++++ b/tools/idf_py_actions/create_ext.py
+@@ -40,7 +40,7 @@ def is_empty_and_create(path: str, action: str) -> None:
+ 
+ 
+ def create_project(target_path: str, name: str) -> None:
+-    copy_tree(os.path.join(os.environ['IDF_PATH'], 'examples', 'get-started', 'sample_project'), target_path)
++    copy_tree(os.path.join(os.environ['IDF_PATH'], 'examples', 'get-started', 'sample_project'), target_path, preserve_mode=0)
+     main_folder = os.path.join(target_path, 'main')
+     os.rename(os.path.join(main_folder, 'main.c'), os.path.join(main_folder, '.'.join((name, 'c'))))
+     replace_in_file(os.path.join(main_folder, 'CMakeLists.txt'), 'main', name)
+@@ -49,7 +49,7 @@ def create_project(target_path: str, name: str) -> None:
+ 
+ 
+ def create_component(target_path: str, name: str) -> None:
+-    copy_tree(os.path.join(os.environ['IDF_PATH'], 'tools', 'templates', 'sample_component'), target_path)
++    copy_tree(os.path.join(os.environ['IDF_PATH'], 'tools', 'templates', 'sample_component'), target_path, preserve_mode=0)
+     os.rename(os.path.join(target_path, 'main.c'), os.path.join(target_path, '.'.join((name, 'c'))))
+     os.rename(os.path.join(target_path, 'include', 'main.h'),
+               os.path.join(target_path, 'include', '.'.join((name, 'h'))))


### PR DESCRIPTION
With esp-idf 5.1.x, "idf.py create-project" fails when the esp-idf templates are in a read-only location (such as the Nix store). By default, they are copied with permissions preserved, and when idf.py attempts to update the freshly made copy of CMakeLists.txt, it fails as the file is read-only.

This change makes the copy have file permissions controlled by the umask, which typically allows writes. The template in nixpkgs is still read-only of course.

This has been fixed upstream in 5.2.