### PR TITLE
added aarch64-linux to platforms

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -29,6 +29,7 @@ let
   # Map nix system strings to the platforms listed in tools.json
   systemToToolPlatformString = {
     "x86_64-linux" = "linux-amd64";
+    "aarch64-linux" = "linux-arm64";
     "x86_64-darwin" = "macos";
     "aarch64-darwin" = "macos-arm64";
   };
@@ -89,7 +90,7 @@ let
       phases = [ "unpackPhase" "installPhase" ];
 
       installPhase = let
-        wrapCmd = if system == "x86_64-linux" then
+        wrapCmd = if (system == "x86_64-linux") || (system == "aarch64-linux") then
         ''
           mv $FILE_PATH $FILE_PATH-unwrapped
           makeWrapper ${fhsEnv}/bin/${pname}-env $FILE_PATH --add-flags "$FILE_PATH-unwrapped" ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}


### PR DESCRIPTION
Hi.
I wanted to use this on a raspberry Pi instead of the docker images. 
I just added arm64 to the platforms list and it got built correctly and worked. kinda surprising :)
Although I'm not sure if this covers everything, as I have only used it for flashing the boards and connecting to the serial port.

closes: https://github.com/mirrexagon/nixpkgs-esp-dev/issues/52