### PR TITLE
patched esp_rfc2217_server imports to load the correct esptool.py file

### DIFF
--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -102,6 +102,20 @@ rec {
       pyyaml
     ];
 
+    # Replaces esptool.py import with .esptool.py-wrapped
+    postInstall = ''
+      sed -i "2s|^|\n\
+      #fix import esptool patch\n\
+      import importlib.util\n\
+      import importlib.machinery\n\
+      esptool_loader = importlib.machinery.SourceFileLoader(\"esptool\", \"$out/bin/.esptool.py-wrapped\")\n\
+      esptool_spec = importlib.util.spec_from_loader(\"esptool\", esptool_loader)\n\
+      esptool_module = importlib.util.module_from_spec(esptool_spec)\n\
+      esptool_spec.loader.exec_module(esptool_module)\n\
+      sys.modules[\"esptool\"] = esptool_module\n\
+      #end of fix import esptool patch\n|" $out/bin/esp_rfc2217_server.py
+    '';
+
     meta = {
       homepage = "https://github.com/espressif/esptool";
     };


### PR DESCRIPTION
Added a patch for esp_rfc2217_server.py to fix the esptool.py import issue.
I'm not sure if there's a better way to do this. The patch takes the esptool.py wrapped path and adds it to sys.modules instead of `esptool`. 
 
I explained the problem more in https://github.com/mirrexagon/nixpkgs-esp-dev/issues/51#issuecomment-2206797848


closes https://github.com/mirrexagon/nixpkgs-esp-dev/issues/51