### PR TITLE
Manually override IDF_VER value

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ NOTE: This doesn't quite work as it should - Python packages won't be adapted fo
 
 See `examples/shell-override-versions.nix` for an example.
 
+### Note about `IDF_VER`
+
+This is a macro describing the version used while building provided by the ESP-IDF toolchain. It is normally generated using `git describe`, but for underlying reasons the build environment can't have access to this git metadata. Fortunately, this repo can emulate this by overriding it to equal the `rev` argument given to `pkgs/esp-idf/default.nix`. This is however not perfect as the output would differ from `git describe` when `rev` is set to a commit hash instead of a tag.
 
 ## Overlay
 This repo contains an overlay in `overlay.nix` containing all the packages defined by this repo. If you clone the repo into `~/.config/nixpkgs/overlays/`, nixpkgs will automatically pick up the overlay and effectively add the packages to your system nixpkgs.

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -126,6 +126,13 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -rv . $out/
 
+    # Override the version read by ESP IDF (as it can't be read in the usual way
+    # since we don't include the .git directory with that metadata).
+    # NOTE: This doesn't perfectly replicate the way the commit name is
+    # formatted with the standard behavior using `git describe`, but it's
+    # still better than nothing.
+    echo "${rev}" > $out/version.txt
+
     # Link the Python environment in so that:
     # - The setup hook can set IDF_PYTHON_ENV_PATH to it.
     # - In shell derivations, the Python setup hook will add the site-packages


### PR DESCRIPTION
Now adds the version.txt file to IDF_PATH with the value of the `rev` argument, so that the `IDF_VER` macro gets a value. It doesn't perferctly replicate the expected behaviour, since I don't feel like simulating `git describe` perfectly, but the behaviour is at least correct when `rev` is set to a tag, like `v5.3`.

This would partly fix https://github.com/mirrexagon/nixpkgs-esp-dev/issues/5. It of course doesn't fix any warnings generated during the build process due to the missing `.git`.