### PR TITLE
Don't wrap programs that don't require it on MacOS.

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -96,7 +96,11 @@ let
           makeWrapper ${fhsEnv}/bin/${pname}-env $FILE_PATH --add-flags $WRAPPED_FILE_PATH ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
         ''
       else
-      ''wrapProgram $FILE_PATH ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}'';
+      ''
+        if [ -n "${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}" ]; then
+          wrapProgram $FILE_PATH ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
+        fi
+      '';
       in ''
         cp -r . $out
 
@@ -122,4 +126,3 @@ let
 
 in
 builtins.listToAttrs (builtins.map (toolSpec: lib.attrsets.nameValuePair toolSpec.name (toolSpecToDerivation toolSpec)) toolSpecList)
-


### PR DESCRIPTION
https://github.com/mirrexagon/nixpkgs-esp-dev/issues/67

Espressif creates a wrapper program for cross-compilers: https://github.com/espressif/esp-toolchain-bin-wrappers The wrapper program defined here parses the output of Rust's `std::env::current_exe()` to perform its function, and it requires that the program name follow a particular schema. This schema is incompatible with the hidden files created by Nix's `wrapProgram` facility, causing compiler invocation to fail.

It seems, though, that `wrapProgram` is unnecessary for these failing scripts: `wrapProgram` sets required environment variables cribbed from ESP-IDF's `tools/tools.json`, but if there are no such variables defined therein, then `wrapProgram` will not change the way execution is intended to work at all. Removing `wrapProgram` in these cases allows ESP-IDF to successfully build an IDF project on MacOS.