### PR TITLE
Add shell and derivation for ESP32-C2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nixpkgs-esp-dev
-ESP8266 and ESP32(-C3, -S2, -S3, -C6, -H2) packages and development environments for Nix.
+ESP8266 and ESP32(-C2, -C3, -S2, -S3, -C6, -H2) packages and development environments for Nix.
 
 This repo contains derivations for ESP-IDF, and most of the toolchains and tools it depends on (compilers for all supported targets, custom OpenOCD for Espressif chips, etc.).
 
@@ -19,6 +19,7 @@ The list of available shells (to go after the `#` in the command) are:
 
 - `esp-idf-full`: Includes toolchains for _all_ supported ESP32 chips (no ESP8266).
 - `esp32-idf`: Includes toolchain for the ESP32.
+- `esp32c2-idf`: Includes toolchain for the ESP32-C2.
 - `esp32c3-idf`: Includes toolchain for the ESP32-C3.
 - `esp32s2-idf`: Includes toolchain for the ESP32-S2.
 - `esp32s3-idf`: Includes toolchain for the ESP32-S3.
@@ -31,6 +32,7 @@ If you're not using Nix 2.4+ or prefer not to need to enable flakes, you can clo
 
 - `nix-shell shells/esp32-idf-full.nix`
 - `nix-shell shells/esp32-idf.nix`
+- `nix-shell shells/esp32c2-idf.nix`
 - `nix-shell shells/esp32c3-idf.nix`
 - `nix-shell shells/esp32s2-idf.nix`
 - `nix-shell shells/esp32s3-idf.nix`

--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
         inherit (pkgs)
           esp-idf-full
           esp-idf-esp32
+          esp-idf-esp32c2
           esp-idf-esp32c3
           esp-idf-esp32s2
           esp-idf-esp32s3
@@ -29,6 +30,7 @@
       devShells = {
         esp-idf-full = import ./shells/esp-idf-full.nix { inherit pkgs; };
         esp32-idf = import ./shells/esp32-idf.nix { inherit pkgs; };
+        esp32c2-idf = import ./shells/esp32c2-idf.nix { inherit pkgs; };
         esp32c3-idf = import ./shells/esp32c3-idf.nix { inherit pkgs; };
         esp32s2-idf = import ./shells/esp32s2-idf.nix { inherit pkgs; };
         esp32s3-idf = import ./shells/esp32s3-idf.nix { inherit pkgs; };

--- a/overlay.nix
+++ b/overlay.nix
@@ -19,6 +19,8 @@ rec {
     ];
   };
 
+  esp-idf-esp32c2 = esp-idf-riscv;
+
   esp-idf-esp32c3 = esp-idf-riscv;
 
   esp-idf-esp32s2 = esp-idf-full.override {

--- a/shells/esp32c2-idf.nix
+++ b/shells/esp32c2-idf.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf-esp32c2-shell";
+
+  buildInputs = with pkgs; [
+    esp-idf-esp32c2
+  ];
+}

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -34,7 +34,7 @@ let
     });
 
   buildsNameList = pkgs.lib.attrsets.cartesianProduct {
-    target = [ "esp32" "esp32c3" "esp32s2" "esp32s3" "esp32c6" "esp32h2" ];
+    target = [ "esp32" "esp32c2" "esp32c3" "esp32s2" "esp32s3" "esp32c6" "esp32h2" ];
     example = [ "get-started/hello_world" ];
   };
 


### PR DESCRIPTION
This adds configuration for the ESP32-C2. It's exactly the same as for the C3 and C6.