### PR TITLE
Clean up tool installation and exported environment variables

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -8,6 +8,7 @@
     "riscv32-esp-elf"
     "esp32ulp-elf"
     "openocd-esp32"
+    "esp-rom-elfs"
   ]
 , stdenv
 , lib

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -45,7 +45,7 @@ let
     versionSuffix = "esp-idf-${rev}";
   };
 
-  toolDerivationsToInclude = builtins.map (toolName: allTools."${toolName}") toolsToInclude;
+  tools = lib.getAttrs toolsToInclude allTools;
 
   customPython =
     (python3.withPackages
@@ -113,7 +113,7 @@ stdenv.mkDerivation rec {
     ncurses5
 
     dfu-util
-  ] ++ toolDerivationsToInclude;
+  ] ++ builtins.attrValues tools;
 
   # We are including cmake and ninja so that downstream derivations (eg. shells)
   # get them in their environment, but we don't actually want any of their build
@@ -142,5 +142,7 @@ stdenv.mkDerivation rec {
     ln -s ${customPython}/lib $out/lib
   '';
 
-  passthru.tools = allTools;
+  passthru = {
+    inherit tools allTools;
+  };
 }

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -141,4 +141,6 @@ stdenv.mkDerivation rec {
     ln -s ${customPython} $out/python-env
     ln -s ${customPython}/lib $out/lib
   '';
+
+  passthru.tools = allTools;
 }

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -13,6 +13,8 @@ addIdfEnvVars() {
         addToSearchPath PATH "${IDF_PATH}/components/espcoredump"
         addToSearchPath PATH "${IDF_PATH}/components/partition_table"
         addToSearchPath PATH "${IDF_PATH}/components/app_update"
+
+	[ -e "$1/.tool-env" ] && . "$1/.tool-env"
     fi
 }
 

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -99,6 +99,8 @@ let
 
       inherit binPaths;
 
+      noDumpEnvVars = true;
+
       installPhase = let
         wrapCmd = if (system == "x86_64-linux") || (system == "aarch64-linux") then
           ''

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -116,6 +116,7 @@ let
       '';
       in ''
         cp -r . $out
+        rm $out/.attrs.*
 
         # For setting exported variables (see exportVarsWrapperArgsList).
         TOOL_PATH=$out


### PR DESCRIPTION
This changes tool installation to be much closer to the native behavior of ESP-IDF. Most notably, we now consume the `export_vars`, `export_paths`, and `strip_container_dirs` fields in `tools.json`, which control how tools should be unpacked. We also propagate all the environment variables from each tool into the setup hook for the IDF package. Taken together, these allow the `esp-rom-elfs` tool to be installed and used, allowing `gdb` to correctly work.

This also means we can remove the openocd-specific hacks in `tools.nix`, since it is now unpacked correctly.