### PR TITLE
Update ESP-IDF 5.3.1 -> 5.4

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,5 +1,5 @@
-{ rev ? "v5.3.1"
-, sha256 ? "sha256-hcE4Tr5PTRQjfiRYgvLB1+8sR7KQQ1TnQJqViodGdBw="
+{ rev ? "v5.4"
+, sha256 ? "sha256-9OQ/0DGwgfR3MkRWd6zSe1FD3Ywt4Ugw8J/BFu1Vfw0="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"
@@ -73,6 +73,8 @@ let
           esp-idf-size
           esp-idf-panic-decoder
           pyclang
+          psutil
+          rich
           argcomplete
 
           freertos_gdb

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -5,11 +5,12 @@
 # Versions found by running this in a fresh venv:
 # pip install -r esp-idf/tools/requirements/requirements.core.txt --constraint=espidf.constraints.v5.3.txt --dry-run
 
-{ stdenv
-, lib
-, fetchPypi
-, fetchFromGitHub
-, pythonPackages
+{
+  stdenv,
+  lib,
+  fetchPypi,
+  fetchFromGitHub,
+  pythonPackages,
 }:
 
 with pythonPackages;
@@ -17,13 +18,13 @@ with pythonPackages;
 rec {
   idf-component-manager = buildPythonPackage rec {
     pname = "idf-component-manager";
-    version = "2.0.4";
+    version = "2.1.2";
     pyproject = true;
 
     src = fetchPypi {
       inherit version;
       pname = "idf_component_manager";
-      sha256 = "sha256-vCyw3nn1r9zkMbqMhXnS9t2kISTqqB56WqlQVq6/6Cs=";
+      sha256 = "sha256-Uc80Rlp4GkjW66e1gkl3pQ10e0Q01Pi2jEWSUpc6sLI=";
     };
 
     build-system = [
@@ -46,6 +47,7 @@ rec {
 
       packaging
       pyyaml
+      ruamel-yaml
       requests
       requests-file
       requests-toolbelt
@@ -291,4 +293,3 @@ rec {
   };
 
 }
-


### PR DESCRIPTION
Because this has GCC 14 which is the first to support C++23's ["explicit object member functions" (aka "deducing this")](https://en.cppreference.com/w/cpp/language/member_functions#Explicit_object_member_functions), which I'm making pretty heavy use of in my projects.