### PR TITLE
esp-idf: move owner and repo in closure parameters for possible override

### DIFF
--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,4 +1,6 @@
-{ rev ? "v5.4"
+{ owner ? "espressif"
+, repo ? "esp-idf"
+, rev ? "v5.4"
 , sha256 ? "sha256-9OQ/0DGwgfR3MkRWd6zSe1FD3Ywt4Ugw8J/BFu1Vfw0="
 , toolsToInclude ? [
     "xtensa-esp-elf-gdb"
@@ -34,10 +36,7 @@
 
 let
   src = fetchFromGitHub {
-    owner = "espressif";
-    repo = "esp-idf";
-    rev = rev;
-    sha256 = sha256;
+    inherit owner repo rev sha256;
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
This allows to use forked version of esp-idf by simple using override.