### PR TITLE
fix: change buildFHSUserEnv to buildFHSEnv

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -9,7 +9,7 @@
 , system
 , lib
 , fetchurl
-, buildFHSUserEnv
+, buildFHSEnv
 , makeWrapper
 
   # Dependencies for the various binary tools.
@@ -72,7 +72,7 @@ let
     }:
 
     let
-      fhsEnv = buildFHSUserEnv {
+      fhsEnv = buildFHSEnv {
         name = "${pname}-env";
         inherit targetPkgs;
         runScript = "";


### PR DESCRIPTION
buildFHSUserEnv is deprecated and will be removed in nixos 25.11. I got this warning when building with a more recent version of nixpkgs.

```
evaluation warning: 'buildFHSUserEnv' has been renamed to 'buildFHSEnv' and will be removed in 25.11
```