### PR TITLE
Fix ESP-IDF-wrapped tools on macOS

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -108,11 +108,7 @@ let
         ''
       else
       ''
-        if [ -n "${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}" ]; then
-          makeWrapper "$file" "$wrapper_file" ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
-        else
-          ln -s "$file" "$wrapper_file"
-        fi
+        makeWrapper "$file" "$wrapper_file" ${lib.strings.concatStringsSep " " exportVarsWrapperArgsList}
       '';
       in ''
         cp -r . $out


### PR DESCRIPTION
ESP-IDF has a wrapper for gcc that looks[^1] in a relative path for other files. We were previously using symlinks for binaries that don't need extra environment variables, but symlinks cause executables to be run with the wrong path in `argv[0]`. Instead, always use a Nix wrapper to ensure that executables are launched from the correct directory.

Fixes #80.

[^1] https://github.com/espressif/esp-toolchain-bin-wrappers/blob/master/gnu-xtensa-toolchian/main.rs