### PR TITLE
default.nix: only show packages of this repo

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,6 @@
-# Returns nixpkgs with the overlay from this repo applied.
-import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; }
+{
+  pkgs ? import <nixpkgs> { },
+  lib ? pkgs.lib,
+}:
+
+lib.makeScope pkgs.newScope (self: import ./overlay.nix self self)


### PR DESCRIPTION
Instead of exporting a variant of the whole nixpkgs repository, we now only export the packages, that we actually provide.
You can see the result with something like this:

```
$ nix-env -f https://github.com/mirrexagon/nixpkgs-esp-dev/archive/pull/88/head.tar.gz -qaP
esp-idf-esp32             esp-idf-v5.4.1
esp-idf-esp32c2           esp-idf-v5.4.1
esp-idf-esp32s2           esp-idf-v5.4.1
esp-idf-esp32s3           esp-idf-v5.4.1
esp-idf-full              esp-idf-v5.4.1
esp8266-nonos-sdk         esp8266-nonos-sdk-3.0.5
esp8266-rtos-sdk          esp8266-rtos-sdk-v3.4
gcc-xtensa-lx106-elf-bin  gcc-xtensa-lx106-elf-bin-2020r3
qemu-esp32                qemu-9.2.2
```

I would argue that this is better because it lets you introspect the repository with well known tooling.
