### PR TITLE
Add C5, fix esp-idf git/python issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 result
+*.vim

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 *.vim
+*.log*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # nixpkgs-esp-dev
-ESP8266 and ESP32(-C2, -C3, -S2, -S3, -C6, -H2) packages and development environments for Nix.
+ESP8266 and ESP32(-C2, -C3, -C5, -S2, -S3, -C6, -H2) packages and development environments for Nix.
 
 This repo contains derivations for ESP-IDF, and most of the toolchains and tools it depends on (compilers for all supported targets, custom OpenOCD for Espressif chips, etc.).
 
@@ -23,6 +23,7 @@ The list of available shells (to go after the `#` in the command) are:
 - `esp32-idf`: Includes toolchain for the ESP32.
 - `esp32c2-idf`: Includes toolchain for the ESP32-C2.
 - `esp32c3-idf`: Includes toolchain for the ESP32-C3.
+- `esp32c5-idf`: Includes toolchain for the ESP32-C5.
 - `esp32s2-idf`: Includes toolchain for the ESP32-S2.
 - `esp32s3-idf`: Includes toolchain for the ESP32-S3.
 - `esp32c6-idf`: Includes toolchain for the ESP32-C6.
@@ -38,6 +39,7 @@ If you're not using Nix 2.4+ or prefer not to need to enable flakes, you can clo
 - `nix-shell shells/esp32-idf.nix`
 - `nix-shell shells/esp32c2-idf.nix`
 - `nix-shell shells/esp32c3-idf.nix`
+- `nix-shell shells/esp32c5-idf.nix`
 - `nix-shell shells/esp32s2-idf.nix`
 - `nix-shell shells/esp32s3-idf.nix`
 - `nix-shell shells/esp32c6-idf.nix`

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             esp-idf-esp32
             esp-idf-esp32c2
             esp-idf-esp32c3
+            esp-idf-esp32c5
             esp-idf-esp32s2
             esp-idf-esp32s3
             esp-idf-esp32c6
@@ -47,6 +48,7 @@
           esp32-idf = import ./shells/esp32-idf.nix { inherit pkgs; };
           esp32c2-idf = import ./shells/esp32c2-idf.nix { inherit pkgs; };
           esp32c3-idf = import ./shells/esp32c3-idf.nix { inherit pkgs; };
+          esp32c5-idf = import ./shells/esp32c5-idf.nix { inherit pkgs; };
           esp32s2-idf = import ./shells/esp32s2-idf.nix { inherit pkgs; };
           esp32s3-idf = import ./shells/esp32s3-idf.nix { inherit pkgs; };
           esp32c6-idf = import ./shells/esp32c6-idf.nix { inherit pkgs; };

--- a/overlay.nix
+++ b/overlay.nix
@@ -25,6 +25,7 @@ final: prev: rec {
   esp-idf-esp32s3 = esp-idf-xtensa;
   esp-idf-esp32c2 = esp-idf-riscv;
   esp-idf-esp32c3 = esp-idf-riscv;
+  esp-idf-esp32c5 = esp-idf-riscv;
   esp-idf-esp32c6 = esp-idf-riscv;
   esp-idf-esp32h2 = esp-idf-riscv;
   esp-idf-esp32p4 = esp-idf-riscv;

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -80,6 +80,7 @@ let
         esp-idf-nvs-partition-gen
         esp-idf-size
         esp-idf-panic-decoder
+        esp-idf-diag
         pyclang
         psutil
         rich

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -15,7 +15,7 @@
   ],
   stdenv,
   lib,
-  fetchFromGitHub,
+  fetchgit,
   makeWrapper,
   callPackage,
 
@@ -36,11 +36,12 @@
 }:
 
 let
-src = fetchFromGitHub {
-  inherit owner repo rev;
+src = fetchgit {
+  url = "https://github.com/${owner}/${repo}.git";
+  inherit rev;
   fetchSubmodules = true;
-  hash = "sha256-5hwoy4QJFZdLApybV0LCxFD2VzM3Y6V7Qv5D3QjI16I=";
-  # tags are fetched explicitly and imperatively in installPhase bc nix fetchers don't support this.
+  fetchTags = true;
+  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 };
 
   allTools = callPackage (import ./tools.nix) {
@@ -158,9 +159,8 @@ installPhase = ''
   git config user.name "nixbld"
   git remote add origin "https://github.com/${owner}/${repo}.git"
   
-  # TODO: we are moving this to runtime, at shell activation time ina shell hook.
-  #git tag "${rev}" HEAD              # create and explicit version tag so git describe works
-  #git fetch origin --tags --depth=1  # fetch tags so git describe works
+  # Create a version tag so git describe works (tags are now fetched by fetchgit)
+  git tag "${rev}" HEAD
   
   # Fix Ownership/Permissions Issues with esp-idf repo
   #   - This package is typically built by a different user than the "end user"

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -41,7 +41,7 @@ src = fetchgit {
   inherit rev;
   fetchSubmodules = true;
   fetchTags = true;
-  hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  hash = "sha256-0YwjUeL1DkwSvLRTRp03UcnY+9IHR1DbLyLHhBP7wHs=";
 };
 
   allTools = callPackage (import ./tools.nix) {

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -9,6 +9,7 @@
   stdenv,
   lib,
   fetchPypi,
+  fetchurl,
   fetchFromGitHub,
   pythonPackages,
 }:
@@ -125,6 +126,34 @@ rec {
 
     meta = {
       homepage = "https://github.com/espressif/esptool";
+    };
+  };
+
+  esp-idf-diag = buildPythonPackage rec {
+    pname = "esp-idf-diag";
+    version = "0.1.1";
+    pyproject = true;
+
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/5f/d9/b9817b5c3859a5434a1d4d734c39fc6556913e7e771f65971df9a7d092b6/esp_idf_diag-0.1.1.tar.gz";
+      sha256 = "4ba922921e957ac6286fc0c0070909eba56584ef0abed2f4fde0fb08c63ff227";
+    };
+
+    build-system = [
+      setuptools
+    ];
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      pyyaml
+      click
+      rich
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-diag";
+      description = "Diagnostic tool for ESP-IDF";
     };
   };
 

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -14,7 +14,12 @@ addIdfEnvVars() {
         addToSearchPath PATH "${IDF_PATH}/components/partition_table"
         addToSearchPath PATH "${IDF_PATH}/components/app_update"
 
-	[ -e "$1/.tool-env" ] && . "$1/.tool-env"
+        [ -e "$1/.tool-env" ] && . "$1/.tool-env"
+      
+        # use a derivation-specific system-level git config if specified
+        if [ -e "$1/etc/gitconfig" ]; then
+            export GIT_CONFIG_SYSTEM="$1/etc/gitconfig"
+        fi
     fi
 }
 

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -21,24 +21,6 @@ addIdfEnvVars() {
         if [ -e "$1/etc/gitconfig" ]; then
             export GIT_CONFIG_SYSTEM="$1/etc/gitconfig"
         fi
-
-        # Fetch tags if we haven't already (to make git describe work)
-        # We have to do this at shell activation time since the existing 
-        # fetchers do not properly fetch tags, and at buildtime
-        # the shell hook does not have network access.
-        if [ -d "$IDF_PATH/.git" ] && [ ! -f "$IDF_PATH/.git/tags_fetched" ]; then
-            echo "Fetching ESP-IDF tags for git describe..."
-            (
-                cd "$IDF_PATH"
-                git remote get-url origin >/dev/null 2>&1 || git remote add origin "https://github.com/espressif/esp-idf.git"
-                if git fetch origin --tags --quiet 2>/dev/null; then
-                    touch "$IDF_PATH/.git/tags_fetched"
-                    echo "Tags fetched successfully."
-                else
-                    echo "Warning: Failed to fetch tags. git describe may not work properly."
-                fi
-            )
-        fi
     fi
 }
 

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -7,6 +7,7 @@ addIdfEnvVars() {
         export IDF_TOOLS_PATH="$IDF_PATH/tools"
         export IDF_PYTHON_CHECK_CONSTRAINTS=no
         export IDF_PYTHON_ENV_PATH="$IDF_PATH/python-env"
+        
         addToSearchPath PATH "$IDF_TOOLS_PATH"
 
         # Extra paths from `export.sh` in the ESP-IDF repo.

--- a/shells/esp-idf-common.nix
+++ b/shells/esp-idf-common.nix
@@ -7,8 +7,5 @@ pkgs.mkShell {
   
   shellHook = ''
     export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-    
-    # Fetch ESP-IDF tags if needed (function defined in setup-hook.sh)
-    fetchEspIdfTags
   '';
 }

--- a/shells/esp-idf-common.nix
+++ b/shells/esp-idf-common.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import ../default.nix, esp-idf-package }:
+
+pkgs.mkShell {
+  name = "${esp-idf-package.pname}-shell";
+
+  buildInputs = [ esp-idf-package ];
+  
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+    
+    # Fetch ESP-IDF tags if needed (function defined in setup-hook.sh)
+    fetchEspIdfTags
+  '';
+}

--- a/shells/esp-idf-full.nix
+++ b/shells/esp-idf-full.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-full-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-full
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-full; }

--- a/shells/esp-idf-full.nix
+++ b/shells/esp-idf-full.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-full
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32-idf.nix
+++ b/shells/esp32-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32-idf.nix
+++ b/shells/esp32-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32; }

--- a/shells/esp32c2-idf.nix
+++ b/shells/esp32c2-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32c2-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32c2
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32c2; }

--- a/shells/esp32c2-idf.nix
+++ b/shells/esp32c2-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32c2
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32c3-idf.nix
+++ b/shells/esp32c3-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32c3-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32c3
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32c3; }

--- a/shells/esp32c3-idf.nix
+++ b/shells/esp32c3-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32c3
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32c5
   ];
+  
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -1,14 +1,17 @@
 { pkgs ? import ../default.nix }:
 
+let
+  esp-idf-custom = pkgs.esp-idf-esp32c5.override { rev = "d930a386dae"; };
+in
 pkgs.mkShell {
   name = "esp-idf-esp32c5-shell";
 
   shellHook = ''
     # Fix git dubious ownership for ESP-IDF
-    git config --global --add safe.directory "$IDF_PATH" 2>/dev/null || true
+    # When you use "${d}" in a Nix string, it automatically converts derivation (d, the build recipe) 
+    # into its output path (where it gets installed in /nix/store/).
+    git config --global --add safe.directory "${esp-idf-custom}" 2>/dev/null || true
   '';
 
-  buildInputs = with pkgs; [
-    ( esp-idf-esp32c5.override { rev = "d930a386dae"; } )
-  ];
+  buildInputs = [ esp-idf-custom ];
 }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -1,17 +1,9 @@
 { pkgs ? import ../default.nix }:
 
-let
-  esp-idf-custom = pkgs.esp-idf-esp32c5.override { rev = "d930a386dae"; };
-in
 pkgs.mkShell {
   name = "esp-idf-esp32c5-shell";
 
-  shellHook = ''
-    # Fix git dubious ownership for ESP-IDF
-    # When you use $${d} in a Nix string, it automatically converts derivation (d, the build recipe) 
-    # into its output path (where it gets installed in /nix/store/).
-    git config --global --add safe.directory "${esp-idf-custom}" 2>/dev/null || true
-  '';
-
-  buildInputs = [ esp-idf-custom ];
+  buildInputs = with pkgs; [
+    esp-idf-esp32c5
+  ];
 }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -8,7 +8,7 @@ pkgs.mkShell {
 
   shellHook = ''
     # Fix git dubious ownership for ESP-IDF
-    # When you use "${d}" in a Nix string, it automatically converts derivation (d, the build recipe) 
+    # When you use $${d} in a Nix string, it automatically converts derivation (d, the build recipe) 
     # into its output path (where it gets installed in /nix/store/).
     git config --global --add safe.directory "${esp-idf-custom}" 2>/dev/null || true
   '';

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import ../default.nix }:
+
+pkgs.mkShell {
+  name = "esp-idf-esp32c5-shell";
+
+  buildInputs = with pkgs; [
+    esp-idf-esp32c5
+  ];
+}

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -3,6 +3,11 @@
 pkgs.mkShell {
   name = "esp-idf-esp32c5-shell";
 
+  shellHook = ''
+    # Fix git dubious ownership for ESP-IDF
+    git config --global --add safe.directory "$IDF_PATH" 2>/dev/null || true
+  '';
+
   buildInputs = with pkgs; [
     ( esp-idf-esp32c5.override { rev = "d930a386dae"; } )
   ];

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -4,6 +4,6 @@ pkgs.mkShell {
   name = "esp-idf-esp32c5-shell";
 
   buildInputs = with pkgs; [
-    esp-idf-esp32c5
+    ( esp-idf-esp32c5.override { rev = "d930a386dae"; } )
   ];
 }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32c5-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32c5
-  ];
-  
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32c5; }

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -8,7 +8,7 @@ pkgs.mkShell {
 
   shellHook = ''
     # Fix git dubious ownership for ESP-IDF
-    # When you use \${d} in a Nix string, it automatically converts derivation (d, the build recipe) 
+    # When you use "${d}" in a Nix string, it automatically converts derivation (d, the build recipe) 
     # into its output path (where it gets installed in /nix/store/).
     git config --global --add safe.directory "${esp-idf-custom}" 2>/dev/null || true
   '';

--- a/shells/esp32c5-idf.nix
+++ b/shells/esp32c5-idf.nix
@@ -8,7 +8,7 @@ pkgs.mkShell {
 
   shellHook = ''
     # Fix git dubious ownership for ESP-IDF
-    # When you use "${d}" in a Nix string, it automatically converts derivation (d, the build recipe) 
+    # When you use \${d} in a Nix string, it automatically converts derivation (d, the build recipe) 
     # into its output path (where it gets installed in /nix/store/).
     git config --global --add safe.directory "${esp-idf-custom}" 2>/dev/null || true
   '';

--- a/shells/esp32c6-idf.nix
+++ b/shells/esp32c6-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32c6-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32c6
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32c6; }

--- a/shells/esp32c6-idf.nix
+++ b/shells/esp32c6-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32c6
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32h2-idf.nix
+++ b/shells/esp32h2-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32h2
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32h2-idf.nix
+++ b/shells/esp32h2-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32h2-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32h2
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32h2; }

--- a/shells/esp32p4-idf.nix
+++ b/shells/esp32p4-idf.nix
@@ -8,4 +8,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32p4
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32p4-idf.nix
+++ b/shells/esp32p4-idf.nix
@@ -1,15 +1,3 @@
-{
-  pkgs ? import ../default.nix,
-}:
+{ pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32p4-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32p4
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32p4; }

--- a/shells/esp32s2-idf.nix
+++ b/shells/esp32s2-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32s2-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32s2
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32s2; }

--- a/shells/esp32s2-idf.nix
+++ b/shells/esp32s2-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32s2
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32s3-idf.nix
+++ b/shells/esp32s3-idf.nix
@@ -6,4 +6,8 @@ pkgs.mkShell {
   buildInputs = with pkgs; [
     esp-idf-esp32s3
   ];
+
+  shellHook = ''
+    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
+  '';
 }

--- a/shells/esp32s3-idf.nix
+++ b/shells/esp32s3-idf.nix
@@ -1,13 +1,3 @@
 { pkgs ? import ../default.nix }:
 
-pkgs.mkShell {
-  name = "esp-idf-esp32s3-shell";
-
-  buildInputs = with pkgs; [
-    esp-idf-esp32s3
-  ];
-
-  shellHook = ''
-    export IDF_PYTHON_ENV_PATH="$(python -c 'import sys; print(sys.prefix)' 2>/dev/null || echo "$IDF_PYTHON_ENV_PATH")"
-  '';
-}
+import ./esp-idf-common.nix { inherit pkgs; esp-idf-package = pkgs.esp-idf-esp32s3; }

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -47,6 +47,7 @@ let
       "esp32s3"
       "esp32c2"
       "esp32c3"
+      "esp32c5"
       "esp32c6"
       "esp32h2"
       "esp32p4"


### PR DESCRIPTION
Added support for the soon-to-be released C5. In the process, I came across some usability issues revolving around a peculiarity of esp-idf: idf.py runs `git describe` and expects git tags to have been fetched. See [this PR](https://github.com/NixOS/nixpkgs/pull/411561) for how I solved that in upstream nixpkgs.

I tested all this in [this branch of my nixcfg repo](https://github.com/timblaktu/nixcfg/tree/thinky-nixos), which uses [my fetchgit fork of nixpkgs](https://github.com/timblaktu/nixpkgs-esp-dev/tree/c5).

Related:
- https://github.com/mirrexagon/nixpkgs-esp-dev/pull/39
- https://github.com/mirrexagon/nixpkgs-esp-dev/issues/5
