### PR TITLE
Expose esp-idf examples as an attribute set

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,34 @@ You can create a standalone `shell.nix` for your project that downloads `nixpkgs
 See `examples/shell-standalone.nix` for an example.
 
 
+## Accessing ESP-IDF Examples
+
+ESP-IDF comes with many example projects that demonstrate various features and capabilities. These examples are accessible as Nix packages through the `examples` attribute of each ESP-IDF package. The examples are organized in a nested attribute set that mirrors the directory structure of ESP-IDF's `examples` directory.
+
+### Building an example
+
+You can build any example using `nix build` with the appropriate attribute path:
+
+```bash
+# Format: .#esp-idf-full.examples.<target>.<path>.<to>.<example>
+nix build .#esp-idf-full.examples.esp32.get-started.hello_world
+```
+
+This will build the "hello_world" example for the ESP32 target. The resulting package includes a flash script that can be used to flash the example to your device:
+
+```bash
+./result/bin/esp32-get-started-hello_world-flash
+```
+
+The flashing script is set as the derivation's main program, making it possible to directly run build and flash the firmware with `nix run`.
+
+```bash
+nix run .#esp-idf-full.examples.esp32.get-started.hello_world
+```
+
+Additional arguments (such as `--port`) are passed directly to `esptool.py`
+
+
 ## Overriding ESP-IDF and ESP32 toolchain versions
 There is a default version of ESP-IDF specified in `pkgs/esp-idf/default.nix`. To use a different version of ESP-IDF or to pin the version, override a `esp-idf-*` derivations with the desired version and the hash for it. The correct version of the tools will be downloaded automatically.
 

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -42,8 +42,6 @@ stdenv.mkDerivation {
   phases = [ "buildPhase" ];
 
   buildPhase = ''
-    set -x
-
     cp -r ${src}/* .
     chmod -R +w .
 

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -1,9 +1,9 @@
-{ stdenv, esp-idf, jq, writeShellApplication }:
+{ lib, stdenv, esp-idf, jq, writeShellApplication }:
 
 { name, target, src }: let
 
   flash = writeShellApplication {
-    name = "flash";
+    name = "${name}-flash";
     text = ''
       set -e
       
@@ -63,7 +63,11 @@ stdenv.mkDerivation {
     cp -r * $out
 
     mkdir $out/bin
-    cp ${flash}/bin/flash $out/bin/
+    cp ${lib.getExe flash} $out/bin/
     '';
+
+  meta = {
+    mainProgram = "${name}-flash";
+  };
 }
 

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -7,7 +7,6 @@
     text = ''
       set -e
       
-      # Default to the current directory if no argument is provided
       SCRIPT_DIR="$(dirname "$(readlink -f "''${BASH_SOURCE[0]}")")"
       cd "$SCRIPT_DIR/../build"
 

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -45,7 +45,7 @@ stdenv.mkDerivation {
     buildPhase = ''
     set -x
 
-    cp -r $IDF_PATH/examples/${example}/* .
+    cp -r ${example}/* .
     chmod -R +w .
 
     # The build system wants to create a cache directory somewhere in the home

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -1,6 +1,6 @@
 { stdenv, esp-idf, jq, writeShellApplication }:
 
-{ target, example }: let
+{ name, target, src }: let
 
   flash = writeShellApplication {
     name = "flash";
@@ -34,18 +34,18 @@
 in
 
 stdenv.mkDerivation {
-    name = "${target}-${builtins.replaceStrings [ "/" ] [ "-" ] example}";
+  inherit name;
 
-    buildInputs = [
-      esp-idf
-    ];
+  buildInputs = [
+    esp-idf
+  ];
 
-    phases = [ "buildPhase" ];
+  phases = [ "buildPhase" ];
 
-    buildPhase = ''
+  buildPhase = ''
     set -x
 
-    cp -r ${example}/* .
+    cp -r ${src}/* .
     chmod -R +w .
 
     # The build system wants to create a cache directory somewhere in the home

--- a/pkgs/esp-idf/build-example.nix
+++ b/pkgs/esp-idf/build-example.nix
@@ -1,0 +1,69 @@
+{ stdenv, esp-idf, jq, writeShellApplication }:
+
+{ target, example }: let
+
+  flash = writeShellApplication {
+    name = "flash";
+    text = ''
+      set -e
+      
+      # Default to the current directory if no argument is provided
+      SCRIPT_DIR="$(dirname "$(readlink -f "''${BASH_SOURCE[0]}")")"
+      cd "$SCRIPT_DIR/../build"
+
+      eval "$(
+        jq -r '.extra_esptool_args | to_entries | map("\(.key)=\(.value|@sh)") | .[]' "flasher_args.json"
+      )"
+
+      stubarg=""
+      if [ "$stub" = "false" ]; then
+        stubarg="--no-stub"
+      fi
+
+      ${esp-idf}/python-env/bin/python3 -m esptool "$@" --chip "$chip" --before "$before" --after "$after" $stubarg write_flash "@flash_args"
+    '';
+
+    checkPhase = "";
+
+    runtimeInputs = [
+      esp-idf
+      jq
+    ];
+  };
+
+in
+
+stdenv.mkDerivation {
+    name = "${target}-${builtins.replaceStrings [ "/" ] [ "-" ] example}";
+
+    buildInputs = [
+      esp-idf
+    ];
+
+    phases = [ "buildPhase" ];
+
+    buildPhase = ''
+    set -x
+
+    cp -r $IDF_PATH/examples/${example}/* .
+    chmod -R +w .
+
+    # The build system wants to create a cache directory somewhere in the home
+    # directory, so we make up a home for it.
+    mkdir temp-home
+    export HOME=$(readlink -f temp-home)
+
+    # idf-component-manager wants to access the network, so we disable it.
+    export IDF_COMPONENT_MANAGER=0
+
+    idf.py set-target ${target}
+    idf.py build
+
+    mkdir $out
+    cp -r * $out
+
+    mkdir $out/bin
+    cp ${flash}/bin/flash $out/bin/
+    '';
+}
+

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -196,15 +196,18 @@ EOF
     };
   };
   buildExample = callPackage ./build-example.nix { inherit esp-idf; };
-  targets = [ 
+  targets = [
     "esp32"
     "esp32c2"
     "esp32c3"
     "esp32s2"
     "esp32s3"
+    "esp32c5"
     "esp32c6"
     "esp32h2"
     "esp32p4"
+    "esp32c61"
+    "esp32h21"
   ];
   in
 esp-idf // {

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -173,6 +173,9 @@ esp-idf = stdenv.mkDerivation rec {
   };
 };
 in
-esp-idf // {
-  example = callPackage ./build-example.nix { inherit esp-idf; };
+esp-idf // rec {
+  buildExample = callPackage ./build-example.nix { inherit esp-idf; };
+  examples = callPackage ./examples.nix { 
+    inherit esp-idf buildExample; 
+  };
 }

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -33,6 +33,7 @@
   ninja,
   ncurses5,
   dfu-util,
+  writeShellApplication,
 }:
 
 let
@@ -92,8 +93,7 @@ let
       ]
     )
   );
-in
-stdenv.mkDerivation rec {
+esp-idf = stdenv.mkDerivation rec {
   pname = "esp-idf";
   version = rev;
 
@@ -171,4 +171,8 @@ stdenv.mkDerivation rec {
   passthru = {
     inherit tools allTools toolEnv;
   };
+};
+in
+esp-idf // {
+  example = callPackage ./build-example.nix { inherit esp-idf; };
 }

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -172,9 +172,9 @@ esp-idf = stdenv.mkDerivation rec {
     inherit tools allTools toolEnv;
   };
 };
+buildExample = callPackage ./build-example.nix { inherit esp-idf; };
 in
-esp-idf // rec {
-  buildExample = callPackage ./build-example.nix { inherit esp-idf; };
+esp-idf // {
   examples = callPackage ./examples.nix { 
     inherit esp-idf buildExample; 
   };

--- a/pkgs/esp-idf/examples.nix
+++ b/pkgs/esp-idf/examples.nix
@@ -2,7 +2,7 @@
 
 let
   # Recursively convert the directory tree into a nested attribute set
-  traverseDir = path:
+  traverseDir = path: prefix:
     let
       entries = builtins.readDir path;
       isLeaf = builtins.hasAttr "sdkconfig.defaults" entries;
@@ -11,11 +11,13 @@ let
       if isLeaf then
         (buildExample {
           target = "esp32c6";
-          example = path;
+          name = "esp32c6-${prefix}";
+          src = path;
         })
       else
-        lib.attrsets.mapAttrs (name: _: traverseDir "${path}/${name}") subdirs;
+        lib.attrsets.mapAttrs (name: _: traverseDir "${path}/${name}" 
+          (if prefix == "" then name else "${prefix}-${name}")) subdirs;
 in
 
 # Call traverseDir on your root path
-traverseDir "${esp-idf}/examples"
+traverseDir "${esp-idf}/examples" ""

--- a/pkgs/esp-idf/examples.nix
+++ b/pkgs/esp-idf/examples.nix
@@ -5,7 +5,8 @@ let
   traverseDir = path: prefix:
     let
       entries = builtins.readDir path;
-      isLeaf = builtins.hasAttr "sdkconfig.defaults" entries;
+      # Check if any file in the directory starts with "sdkconfig"
+      isLeaf = lib.any (name: lib.hasPrefix "sdkconfig" name) (builtins.attrNames entries);
       subdirs = lib.attrsets.filterAttrs (_: type: type == "directory") entries;
     in
       if isLeaf then

--- a/pkgs/esp-idf/examples.nix
+++ b/pkgs/esp-idf/examples.nix
@@ -1,4 +1,4 @@
-{ lib, esp-idf, buildExample }:
+{ lib, esp-idf, buildExample, target }:
 
 let
   # Recursively convert the directory tree into a nested attribute set
@@ -10,8 +10,8 @@ let
     in
       if isLeaf then
         (buildExample {
-          target = "esp32c6";
-          name = "esp32c6-${prefix}";
+          target = target;
+          name = "${target}-${prefix}";
           src = path;
         })
       else

--- a/pkgs/esp-idf/examples.nix
+++ b/pkgs/esp-idf/examples.nix
@@ -1,0 +1,21 @@
+{ lib, esp-idf, buildExample }:
+
+let
+  # Recursively convert the directory tree into a nested attribute set
+  traverseDir = path:
+    let
+      entries = builtins.readDir path;
+      isLeaf = builtins.hasAttr "sdkconfig.defaults" entries;
+      subdirs = lib.attrsets.filterAttrs (_: type: type == "directory") entries;
+    in
+      if isLeaf then
+        (buildExample {
+          target = "esp32c6";
+          example = path;
+        })
+      else
+        lib.attrsets.mapAttrs (name: _: traverseDir "${path}/${name}") subdirs;
+in
+
+# Call traverseDir on your root path
+traverseDir "${esp-idf}/examples"

--- a/pkgs/esp-idf/examples.nix
+++ b/pkgs/esp-idf/examples.nix
@@ -6,19 +6,22 @@ let
     let
       entries = builtins.readDir path;
       # Check if any file in the directory starts with "sdkconfig"
-      isLeaf = lib.any (name: lib.hasPrefix "sdkconfig" name) (builtins.attrNames entries);
-      subdirs = lib.attrsets.filterAttrs (_: type: type == "directory") entries;
+      isLeaf = lib.any (name: lib.hasPrefix "sdkconfig" name) (lib.attrNames entries);
+      # Filter to only include directories
+      subdirs = lib.filterAttrs (_: type: type == "directory") entries;
     in
       if isLeaf then
+        # This is a leaf node (an actual example project)
         (buildExample {
-          target = target;
+          inherit target;
           name = "${target}-${prefix}";
           src = path;
         })
       else
-        lib.attrsets.mapAttrs (name: _: traverseDir "${path}/${name}" 
-          (if prefix == "" then name else "${prefix}-${name}")) subdirs;
+        # Continue traversing subdirectories
+        lib.mapAttrs 
+          (name: _: traverseDir "${path}/${name}" 
+            (if prefix == "" then name else "${prefix}-${name}")) 
+          subdirs;
 in
-
-# Call traverseDir on your root path
 traverseDir "${esp-idf}/examples" ""

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -1,7 +1,5 @@
 { pkgs }:
 
-with pkgs.lib;
-
 let
   buildsNameList = pkgs.lib.attrsets.cartesianProduct {
     target = [
@@ -22,8 +20,8 @@ let
       spec:
       let
         # Build each of these with both esp-idf-full and the appropriate esp-idf-esp32xx.
-        buildFull = attrByPath spec.example null pkgs.esp-idf-full.examples.${spec.target};
-        buildSpecific = attrByPath spec.example null pkgs."esp-idf-${spec.target}".examples.${spec.target};
+        buildFull = pkgs.lib.attrByPath spec.example null pkgs.esp-idf-full.examples.${spec.target};
+        buildSpecific = pkgs.lib.attrByPath spec.example null pkgs."esp-idf-${spec.target}".examples.${spec.target};
       in
       [
         (pkgs.lib.attrsets.nameValuePair buildFull.name buildFull)

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -8,9 +8,12 @@ let
       "esp32s3"
       "esp32c2"
       "esp32c3"
+      "esp32c5"
       "esp32c6"
       "esp32h2"
       "esp32p4"
+      "esp32c61"
+      "esp32h21"
     ];
     example = [ [ "get-started" "hello_world" ] ];
   };

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -51,7 +51,7 @@ let
       "esp32h2"
       "esp32p4"
     ];
-    example = [ "get-started/hello_world" ];
+    example = [ "get-started/hello_world" "openthread/ot_rcp" ];
   };
 
   buildsList = pkgs.lib.lists.flatten (


### PR DESCRIPTION
I often need to flash some useul examples (like openthread's ot_rcp) on a device without modifying them. This PR maps the full `examples` directory tree as an attribute set, and adds a helper script to flash it to your device. It uses the presence of an `sdkconfig` file to consider a directory an example rather than a container.

To build and flash the hello_world example for esp32, you would use:
```bash
nix run .#esp-idf-full.examples.esp32.get-started.hello_world
```

The full syntax is `.#esp-idf-full.examples.<target>.<path>.<to>.<example>`.