### PR TITLE
Bump ESP-IDF to 5.5 and start deprecating notice for chip-specific shells and derivations

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,17 +20,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729501122,
-        "narHash": "sha256-tScdcYQ37kMqlyqb5yizNDTKXZASLB4zHitlHwOg+/o=",
+        "lastModified": 1753749649,
+        "narHash": "sha256-+jkEZxs7bfOKfBIk430K+tK9IvXlwzqQQnppC2ZKFj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "56c7c4a3f5fdbef5bf81c7d9c28fbb45dc626611",
+        "rev": "1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "ref": "nixpkgs-unstable",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
             esp-idf-esp32h2
             esp-idf-esp32p4
             gcc-xtensa-lx106-elf-bin
-            esp8266-rtos-sdk
+            # esp8266-rtos-sdk # Broken
             esp8266-nonos-sdk
             ;
         };
@@ -54,13 +54,14 @@
           esp32c6-idf = import ./shells/esp32c6-idf.nix { inherit pkgs; };
           esp32h2-idf = import ./shells/esp32h2-idf.nix { inherit pkgs; };
           esp32p4-idf = import ./shells/esp32p4-idf.nix { inherit pkgs; };
-          esp8266-rtos-sdk = import ./shells/esp8266-rtos-sdk.nix { inherit pkgs; };
+          # esp8266-rtos-sdk = import ./shells/esp8266-rtos-sdk.nix { inherit pkgs; }; # Broken
           esp8266-nonos-sdk = import ./shells/esp8266-nonos-sdk.nix { inherit pkgs; };
         };
 
         checks =
-          (import ./tests/build-idf-examples.nix { inherit pkgs; })
-          // (import ./tests/build-esp8266-example.nix { inherit pkgs; });
+          (import ./tests/build-idf-examples.nix { inherit pkgs; });
+          # For now, the esp8266-rtos-sdk is broken upstream (https://github.com/mirrexagon/nixpkgs-esp-dev/issues/94).
+          # // (import ./tests/build-esp8266-example.nix { inherit pkgs; });
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
         packages = {
           inherit (pkgs)
             esp-idf-full
+            esp-idf-riscv
+            esp-idf-xtensa
             esp-idf-esp32
             esp-idf-esp32c2
             esp-idf-esp32c3

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ESP8266/ESP32 development tools";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,4 +1,4 @@
-final: prev: rec {
+final: prev: let
   esp-idf-full = prev.callPackage ./pkgs/esp-idf { };
 
   esp-idf-xtensa = esp-idf-full.override {
@@ -20,14 +20,27 @@ final: prev: rec {
     ];
   };
 
-  esp-idf-esp32 = esp-idf-xtensa;
-  esp-idf-esp32s2 = esp-idf-xtensa;
-  esp-idf-esp32s3 = esp-idf-xtensa;
-  esp-idf-esp32c2 = esp-idf-riscv;
-  esp-idf-esp32c3 = esp-idf-riscv;
-  esp-idf-esp32c6 = esp-idf-riscv;
-  esp-idf-esp32h2 = esp-idf-riscv;
-  esp-idf-esp32p4 = esp-idf-riscv;
+  mkDeprecatedAlias = arch: name: alias: {
+    "${name}" = builtins.warn ''
+        [DEPRECATION WARNING] `${name}` is deprecated and will be removed starting with ESP-IDF 6.0.
+        Please use `esp-idf-full` or `esp-idf-${arch}` instead.
+
+        More information here : https://github.com/mirrexagon/nixpkgs-esp-dev/issues/91
+      '' alias;
+  };
+
+  deprecatedAlias = builtins.foldl' (acc: pair: acc // (mkDeprecatedAlias pair.arch pair.name pair.alias)) {} [
+    { name = "esp-idf-esp32"; alias = esp-idf-xtensa; arch = "xtensa"; }
+    { name = "esp-idf-esp32s2"; alias = esp-idf-xtensa; arch = "xtensa"; }
+    { name = "esp-idf-esp32s3"; alias = esp-idf-xtensa; arch = "xtensa"; }
+    { name = "esp-idf-esp32c2"; alias = esp-idf-riscv;  arch = "riscv"; }
+    { name = "esp-idf-esp32c3"; alias = esp-idf-riscv;  arch = "riscv"; }
+    { name = "esp-idf-esp32c6"; alias = esp-idf-riscv;  arch = "riscv"; }
+    { name = "esp-idf-esp32h2"; alias = esp-idf-riscv;  arch = "riscv"; }
+    { name = "esp-idf-esp32p4"; alias = esp-idf-riscv;  arch = "riscv"; }
+  ];
+in deprecatedAlias // {
+  inherit esp-idf-full esp-idf-xtensa esp-idf-riscv;
 
   # ESP8266
   gcc-xtensa-lx106-elf-bin = prev.callPackage ./pkgs/esp8266/gcc-xtensa-lx106-elf-bin.nix { };

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -143,12 +143,15 @@ stdenv.mkDerivation rec {
     mkdir -p $out
     cp -rv . $out/
 
-    # Override the version read by ESP IDF (as it can't be read in the usual way
-    # since we don't include the .git directory with that metadata).
-    # NOTE: This doesn't perfectly replicate the way the commit name is
-    # formatted with the standard behavior using `git describe`, but it's
-    # still better than nothing.
-    echo "${rev}" > $out/version.txt
+    # Inspired from how idf.py find the version in the sources.
+    # https://github.com/espressif/esp-idf/blob/4e036983a751e4667ade94c8f6f6bf1e7f78eff0/tools/idf_py_actions/tools.py#L82
+    IDF_VERSION=$(cat $out/tools/cmake/version.cmake | awk '
+      /set\(IDF_VERSION_MAJOR/ && match($0, /[0-9]+/, m) { major = m[0] }
+      /set\(IDF_VERSION_MINOR/ && match($0, /[0-9]+/, m) { minor = m[0] }
+      /set\(IDF_VERSION_PATCH/ && match($0, /[0-9]+/, m) { patch = m[0] }
+      END { print major "." minor "." patch }
+    ')
+    echo "v$IDF_VERSION" > $out/version.txt
 
     # Link the Python environment in so that:
     # - The setup hook can set IDF_PYTHON_ENV_PATH to it.
@@ -167,6 +170,23 @@ stdenv.mkDerivation rec {
     git config user.email "nixbld@localhost"
     git config user.name "nixbld"
     git commit --date="1970-01-01 00:00:00" --allow-empty -m "make idf happy"
+
+    # Create a version tag so git describe works
+    git tag "$(cat $out/version.txt)" HEAD
+
+    # Fix Ownership/Permissions Issues with esp-idf repo
+    #   - This package is typically built by a different user than the "end user"
+    #   - The esp-idf build tools execute git on its own working tree, which requires end user access
+    #   - It is not feasible to change ownership or permissions of nix store content, and we don't want to just run as root, so
+    #     the solution it to explicitly configure the git client to trust the esp-idf directory in the nix store
+    #   - Here we add a system-level git configuration file in the package derivation.
+    #   - Git config file location is referred to by the GIT_CONFIG_GLOBAL var exported by shell hook at runtime
+    #   - User- and repo-level git configs are not masked, all are read and merged per https://git-scm.com/docs/git-config#FILES
+    mkdir -p $out/etc
+    cat > $out/etc/gitconfig << EOF
+[safe]
+	directory = $out
+EOF
   '';
 
   passthru = {

--- a/pkgs/esp-idf/default.nix
+++ b/pkgs/esp-idf/default.nix
@@ -1,8 +1,8 @@
 {
   owner ? "espressif",
   repo ? "esp-idf",
-  rev ? "v5.4.1",
-  sha256 ? "sha256-5hwoy4QJFZdLApybV0LCxFD2VzM3Y6V7Qv5D3QjI16I=",
+  rev ? "v5.5",
+  sha256 ? "sha256-5G3IBVkpt8uuFzazwVHiwnqfMig3aMYmfcpKyMPWCBI=",
   toolsToInclude ? [
     "xtensa-esp-elf-gdb"
     "riscv32-esp-elf-gdb"
@@ -75,11 +75,12 @@ let
         idf-component-manager
         esp-coredump
         esptool
+        esp-idf-diag
         esp-idf-kconfig
         esp-idf-monitor
         esp-idf-nvs-partition-gen
-        esp-idf-size
         esp-idf-panic-decoder
+        esp-idf-size
         pyclang
         psutil
         rich

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -90,6 +90,11 @@ with pythonPackages; rec {
   esptool = buildPythonPackage rec {
     pname = "esptool";
     version = "4.9.1";
+    pyproject = true;
+
+    build-system = [
+      setuptools
+    ];
 
     src = fetchPypi {
       inherit pname version;
@@ -99,6 +104,8 @@ with pythonPackages; rec {
     doCheck = false;
 
     propagatedBuildInputs = [
+      intelhex
+      argcomplete
       bitstring
       cryptography
       ecdsa
@@ -189,6 +196,11 @@ with pythonPackages; rec {
   esp-idf-size = buildPythonPackage rec {
     pname = "esp-idf-size";
     version = "1.7.1";
+    pyproject = true;
+
+    build-system = [
+      setuptools
+    ];
 
     src = fetchPypi {
       inherit version;
@@ -199,6 +211,7 @@ with pythonPackages; rec {
     doCheck = false;
 
     propagatedBuildInputs = [
+      rich
       pyyaml
     ];
 
@@ -236,6 +249,11 @@ with pythonPackages; rec {
   pyclang = buildPythonPackage rec {
     pname = "pyclang";
     version = "0.6.3";
+    pyproject = true;
+
+    build-system = [
+      setuptools
+    ];
 
     src = fetchPypi {
       inherit pname version;
@@ -252,6 +270,11 @@ with pythonPackages; rec {
   freertos_gdb = buildPythonPackage rec {
     pname = "freertos-gdb";
     version = "1.0.4";
+    pyproject = true;
+
+    build-system = [
+      setuptools
+    ];
 
     src = fetchPypi {
       inherit pname version;
@@ -259,9 +282,6 @@ with pythonPackages; rec {
     };
 
     doCheck = false;
-
-    propagatedBuildInputs = [
-    ];
 
     meta = {
       homepage = "https://github.com/espressif/freertos-gdb";
@@ -271,8 +291,11 @@ with pythonPackages; rec {
   esp-idf-panic-decoder = buildPythonPackage rec {
     pname = "esp-idf-panic-decoder";
     version = "1.4.1";
+    pyproject = true;
 
-    format = "pyproject";
+    build-system = [
+      setuptools
+    ];
 
     src = fetchPypi {
       inherit version;
@@ -284,7 +307,6 @@ with pythonPackages; rec {
 
     propagatedBuildInputs = [
       pyelftools
-      setuptools
     ];
 
     meta = {

--- a/pkgs/esp-idf/python-packages.nix
+++ b/pkgs/esp-idf/python-packages.nix
@@ -1,30 +1,24 @@
 # Versions based on
-# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.3.txt
-# on 2024-10-23.
+# https://dl.espressif.com/dl/esp-idf/espidf.constraints.v5.5.txt
+# on 2025-07-18.
 #
 # Versions found by running this in a fresh venv:
-# pip install -r esp-idf/tools/requirements/requirements.core.txt --constraint=espidf.constraints.v5.3.txt --dry-run
-
+# pip install -r esp-idf/tools/requirements/requirements.core.txt --constraint=espidf.constraints.v5.5.txt --dry-run
 {
-  stdenv,
-  lib,
   fetchPypi,
-  fetchFromGitHub,
+  fetchurl,
   pythonPackages,
 }:
-
-with pythonPackages;
-
-rec {
+with pythonPackages; rec {
   idf-component-manager = buildPythonPackage rec {
     pname = "idf-component-manager";
-    version = "2.1.2";
+    version = "2.2.2";
     pyproject = true;
 
     src = fetchPypi {
       inherit version;
       pname = "idf_component_manager";
-      sha256 = "sha256-Uc80Rlp4GkjW66e1gkl3pQ10e0Q01Pi2jEWSUpc6sLI=";
+      sha256 = "sha256-HKOJIThQ05khSBhDzVjX+cF2hWrBivNZXmQZWBpIGvc=";
     };
 
     build-system = [
@@ -32,30 +26,33 @@ rec {
     ];
     doCheck = false;
 
-    propagatedBuildInputs = [
-      cachecontrol
-      cffi
-      click
-      colorama
-      jsonref
+    propagatedBuildInputs =
+      [
+        cachecontrol
+        cffi
+        click
+        colorama
+        jsonref
 
-      pydantic
-      pydantic-core
-      pydantic-core
-      pydantic-settings
-      pyparsing
+        pydantic
+        pydantic-core
+        pydantic-core
+        pydantic-settings
+        pyparsing
 
-      packaging
-      pyyaml
-      ruamel-yaml
-      requests
-      requests-file
-      requests-toolbelt
-      schema
-      six
-      tqdm
-      typing-extensions
-    ] ++ cachecontrol.optional-dependencies.filecache;
+        packaging
+        pyyaml
+        ruamel-yaml
+        requests
+        requests-file
+        requests-toolbelt
+        schema
+        six
+        tqdm
+        typing-extensions
+        truststore
+      ]
+      ++ cachecontrol.optional-dependencies.filecache;
 
     meta = {
       homepage = "https://github.com/espressif/idf-component-manager";
@@ -64,12 +61,13 @@ rec {
 
   esp-coredump = buildPythonPackage rec {
     pname = "esp-coredump";
-    version = "1.12.0"; # TODO: 1.13.1 returns 404 when downloading
+    version = "1.13.1";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-s/JKD9PwcU7OZ3x4U4ScCRILvc1Ors0hkXHiRV+R+tg=";
+      inherit version;
+      pname = "esp_coredump";
+      sha256 = "sha256-rz0HbQ4DHB7vClZICYW/Q13N+48MWqEpnup0TyYFzIk=";
     };
 
     build-system = [
@@ -91,11 +89,11 @@ rec {
 
   esptool = buildPythonPackage rec {
     pname = "esptool";
-    version = "4.8.1";
+    version = "4.9.1";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-3E7ya2WeGo3LAZFHwOptlJgLNN6Z++CRIceUHIslRTE=";
+      sha256 = "sha256-qMDmKxZGkik1wqG6knfuMNYy6ziiH92z603iJ9j+07o=";
     };
 
     doCheck = false;
@@ -161,12 +159,13 @@ rec {
 
   esp-idf-monitor = buildPythonPackage rec {
     pname = "esp-idf-monitor";
-    version = "1.5.0"; # TODO: 1.6.2 and 1.6.0 return 404 when downloading
+    version = "1.7.0";
     pyproject = true;
 
     src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-kGz1uY8KwQ1E/a7YZdZItLou8au5zfHEva/Q/g0aQuQ=";
+      inherit version;
+      pname = "esp_idf_monitor";
+      sha256 = "sha256-lU5ec8f7d3R+PzBkfiCVbYbnD7ZO1rOJC3TA5ulKGdk=";
     };
 
     build-system = [
@@ -189,11 +188,12 @@ rec {
 
   esp-idf-size = buildPythonPackage rec {
     pname = "esp-idf-size";
-    version = "1.6.1";
+    version = "1.7.1";
 
     src = fetchPypi {
-      inherit pname version;
-      sha256 = "sha256-Oki21JiHiS7PzfIj/uQXSjc1KArRKBEDDLRvpQqBI/o=";
+      inherit version;
+      pname = "esp_idf_size";
+      sha256 = "sha256-labUYKJukzADWq8eHCXM83FgVJdWIUMgzMqEBNl9zBs=";
     };
 
     doCheck = false;
@@ -209,13 +209,13 @@ rec {
 
   esp-idf-nvs-partition-gen = buildPythonPackage rec {
     pname = "esp-idf-nvs-partition-gen";
-    version = "0.1.6";
+    version = "0.1.9";
     pyproject = true;
 
     src = fetchPypi {
       inherit version;
       pname = "esp_idf_nvs_partition_gen";
-      hash = "sha256-511QNGnWJun37fOcH+A923mXM4YDWw/E0kppnNcdiJQ=";
+      hash = "sha256-Q6ObVLJDGJ6REJpOmZaMhk8y4g4Ne5wzBSu9JqXxaQ8=";
     };
 
     build-system = [
@@ -226,7 +226,7 @@ rec {
       cryptography
     ];
 
-    pythonImportsCheck = [ "esp_idf_nvs_partition_gen" ];
+    pythonImportsCheck = ["esp_idf_nvs_partition_gen"];
 
     meta = {
       homepage = "https://pypi.org/project/esp-idf-nvs-partition-gen/";
@@ -235,11 +235,11 @@ rec {
 
   pyclang = buildPythonPackage rec {
     pname = "pyclang";
-    version = "0.6.0";
+    version = "0.6.3";
 
     src = fetchPypi {
       inherit pname version;
-      sha256 = "sha256-G+Y24AiTOpjLg+eQGAT/CTCK0/vomqjNZloXTmWqRQM=";
+      sha256 = "sha256-CxFRwZhiGfQcuRpXcyQQlejSKD/qqPlHyYnGWE/E1Wo=";
     };
 
     doCheck = false;
@@ -270,14 +270,14 @@ rec {
 
   esp-idf-panic-decoder = buildPythonPackage rec {
     pname = "esp-idf-panic-decoder";
-    version = "1.3.0";
+    version = "1.4.1";
 
     format = "pyproject";
 
     src = fetchPypi {
       inherit version;
       pname = "esp_idf_panic_decoder";
-      sha256 = "sha256-INLVdgoLNVl0Mik9MyVCXoQRt34eVnvvaiBO0KuSSTI=";
+      sha256 = "sha256-l0HQFZlWB0PkiK4EkiIotYBkX5hXHCu9v+f0noUcKwM=";
     };
 
     doCheck = false;
@@ -289,6 +289,34 @@ rec {
 
     meta = {
       homepage = "https://github.com/espressif/esp-idf-panic-decoder";
+    };
+  };
+
+  esp-idf-diag = buildPythonPackage {
+    pname = "esp-idf-diag";
+    version = "0.2.0";
+    pyproject = true;
+
+    src = fetchurl {
+      url = "https://github.com/espressif/esp-idf-diag/archive/refs/tags/v0.2.0.tar.gz";
+      sha256 = "sha256-YEwLBYOveUl1xmZeZScXzY98PLCEWGgomt3t1WjJPJQ=";
+    };
+
+    build-system = [
+      setuptools
+    ];
+
+    doCheck = false;
+
+    propagatedBuildInputs = [
+      pyyaml
+      click
+      rich
+    ];
+
+    meta = {
+      homepage = "https://github.com/espressif/esp-idf-diag";
+      description = "Diagnostic tool for ESP-IDF";
     };
   };
 }

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -6,7 +6,7 @@ addIdfEnvVars() {
         export IDF_PATH="$1"
         export IDF_TOOLS_PATH="$IDF_PATH/tools"
         export IDF_PYTHON_CHECK_CONSTRAINTS=no
-        export IDF_PYTHON_ENV_PATH="$IDF_PATH/python-env"
+        export IDF_PYTHON_ENV_PATH="$(readlink $IDF_PATH/python-env)"
         addToSearchPath PATH "$IDF_TOOLS_PATH"
 
         # Extra paths from `export.sh` in the ESP-IDF repo.

--- a/pkgs/esp-idf/setup-hook.sh
+++ b/pkgs/esp-idf/setup-hook.sh
@@ -14,7 +14,12 @@ addIdfEnvVars() {
         addToSearchPath PATH "${IDF_PATH}/components/partition_table"
         addToSearchPath PATH "${IDF_PATH}/components/app_update"
 
-	[ -e "$1/.tool-env" ] && . "$1/.tool-env"
+        [ -e "$1/.tool-env" ] && . "$1/.tool-env"
+
+        # use a derivation-specific system-level git config if specified
+        if [ -e "$1/etc/gitconfig" ]; then
+            export GIT_CONFIG_SYSTEM="$1/etc/gitconfig"
+        fi
     fi
 }
 

--- a/pkgs/esp8266/esp8266-rtos-sdk/esp8266-rtos-sdk.nix
+++ b/pkgs/esp8266/esp8266-rtos-sdk/esp8266-rtos-sdk.nix
@@ -107,4 +107,6 @@ stdenv.mkDerivation rec {
     ln -s ${customPython} $out/python-env
     ln -s ${customPython}/lib $out/lib
   '';
+
+  meta.broken = true;
 }

--- a/shells/esp32-idf.nix
+++ b/shells/esp32-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32-shell";
 

--- a/shells/esp32c2-idf.nix
+++ b/shells/esp32c2-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32c2-shell";
 

--- a/shells/esp32c3-idf.nix
+++ b/shells/esp32c3-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32c3-shell";
 

--- a/shells/esp32c6-idf.nix
+++ b/shells/esp32c6-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32c6-shell";
 

--- a/shells/esp32h2-idf.nix
+++ b/shells/esp32h2-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32h2-shell";
 

--- a/shells/esp32p4-idf.nix
+++ b/shells/esp32p4-idf.nix
@@ -2,6 +2,8 @@
   pkgs ? import ../default.nix,
 }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32p4-shell";
 

--- a/shells/esp32s2-idf.nix
+++ b/shells/esp32s2-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32s2-shell";
 

--- a/shells/esp32s3-idf.nix
+++ b/shells/esp32s3-idf.nix
@@ -1,5 +1,7 @@
 { pkgs ? import ../default.nix }:
 
+builtins.warn "[DEPRECATION WARNING] Chip specific shell will be removed starting ESP-IDF 6.0. Use esp-idf-full instead."
+
 pkgs.mkShell {
   name = "esp-idf-esp32s3-shell";
 

--- a/tests/build-idf-examples.nix
+++ b/tests/build-idf-examples.nix
@@ -32,7 +32,7 @@ let
         # idf-component-manager wants to access the network, so we disable it.
         export IDF_COMPONENT_MANAGER=0
 
-        idf.py set-target ${target}
+        idf.py --preview set-target ${target}
         idf.py build
 
         mkdir $out
@@ -47,9 +47,12 @@ let
       "esp32s3"
       "esp32c2"
       "esp32c3"
+      "esp32c5"
       "esp32c6"
       "esp32h2"
       "esp32p4"
+      "esp32c61"
+      "esp32h21"
     ];
     example = [ "get-started/hello_world" ];
   };
@@ -69,7 +72,7 @@ let
         buildSpecific = build-idf-example (
           spec
           // {
-            esp-idf = pkgs."esp-idf-${spec.target}";
+            esp-idf = pkgs."esp-idf-${spec.target}" or pkgs.esp-idf-full;
             suffix = "specific";
           }
         );


### PR DESCRIPTION
This merge request bumps the Python dependencies to the latest versions pinned by ESP-IDF 5.5 and also introduces a notice for chip-specific shells and derivations, in preparation for their removal when ESP-IDF 6.0 is released.

I tried the version proposed in #92 and feel the same way as the comment (https://github.com/mirrexagon/nixpkgs-esp-dev/pull/92#issuecomment-3036948379) so chose to keep with what we already had (fetchFromGithub).