### PR TITLE
qemu-esp32: 9.2.2-20250228 -> 9.2.2-20250817

### DIFF
--- a/pkgs/qemu-esp32/default.nix
+++ b/pkgs/qemu-esp32/default.nix
@@ -43,8 +43,8 @@
       src = fetchFromGitHub {
         owner = "espressif";
         repo = "qemu";
-        rev = "esp-develop-9.2.2-20250228";
-        hash = "sha256-cxYg2ssVIkoYhwpLD1b2GW1nPIoPyHnW/gIrPJV0vTI=";
+        rev = "esp-develop-9.2.2-20250817";
+        hash = "sha256-6bL6v231xD/H1DB+ze3eW2x3VCHlE/nXqOmu3RKk8c4=";
         nativeBuildInputs = [
           cacert
           git


### PR DESCRIPTION
https://github.com/espressif/qemu/releases/tag/esp-develop-9.2.2-20250817

Diff: https://github.com/espressif/qemu/compare/esp-develop-9.2.2-20250228...esp-develop-9.2.2-20250817