### PR TITLE
fix qemu-esp32 hash

### DIFF
--- a/pkgs/qemu-esp32/default.nix
+++ b/pkgs/qemu-esp32/default.nix
@@ -44,7 +44,7 @@
         owner = "espressif";
         repo = "qemu";
         rev = "esp-develop-9.2.2-20250817";
-        hash = "sha256-6bL6v231xD/H1DB+ze3eW2x3VCHlE/nXqOmu3RKk8c4=";
+        hash = "sha256-482BeOmWkaOn2H3inH7sZADsxV331Nssbs+6iYCTFCg=";
         nativeBuildInputs = [
           cacert
           git


### PR DESCRIPTION
it seems that the qemu esp-develop-9.2.2-20250817 release has been modified since it was first made:
<img width="1238" height="118" alt="image" src="https://github.com/user-attachments/assets/3a8e02a4-fbe8-4e7a-b301-964e7b71f8ad" />