### PR TITLE
Add symlink to tool/lib dir

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -128,6 +128,12 @@ let
             ${wrapCmd}
           done
         done
+
+        # for clangd to find the system headers
+        libdir=''${bindir%/bin}/lib
+        if [ -d $out/$libdir ]; then
+          ln -s $libdir $out/lib
+        fi
       '';
 
       meta = with lib; {


### PR DESCRIPTION
clangd looks for system includes (e.g. stdio.h) based on `which riscv32-esp-elf-cc` or something similar. So our wrappers cause it to look in a missing directory.
This PR adds a symlink, so that clangd finds what it looks for even despite it uses a different path.
Fix #106.
