### PR TITLE
Replace `system` with `stdenv.hostPlatform.system`

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -2,7 +2,6 @@
 , versionSuffix # A string to use in the version of the tool derivations.
 
 , stdenv
-, system
 , lib
 , fetchurl
 , makeWrapper
@@ -47,7 +46,7 @@ let
 
   toolSpecToDerivation = toolSpec:
     let
-      targetPlatform = systemToToolPlatformString.${system};
+      targetPlatform = systemToToolPlatformString.${stdenv.hostPlatform.system};
       targetVersionSpecs = builtins.elemAt toolSpec.versions 0;
       targetVersionSpec = targetVersionSpecs.${targetPlatform} or targetVersionSpecs.any;
       platformOverrides = builtins.filter (o: lib.elem targetPlatform o.platforms) (toolSpec.platform_overrides or []);


### PR DESCRIPTION
This fixes a deprecation warning:
```
evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'
```