### PR TITLE
flake: bump nixpkgs to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758070117,
-        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "lastModified": 1767799921,
+        "narHash": "sha256-r4GVX+FToWVE2My8VVZH4V0pTIpnu2ZE8/Z4uxGEMBE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "rev": "d351d0653aeb7877273920cd3e823994e7579b0b",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "ESP8266/ESP32 development tools";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -21,6 +21,9 @@
         pkgs = import nixpkgs {
           inherit system;
           overlays = [ self.overlays.default ];
+          config.permittedInsecurePackages = [
+            "python3.13-ecdsa-0.19.1"
+          ];
         };
       in
       {

--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -17,7 +17,7 @@
 , python310
 , python311
 , python312
-, libxml2
+, libxml2_13
 }:
 
 let
@@ -41,7 +41,7 @@ let
     python310
     python311
     python312
-    libxml2
+    libxml2_13
   ];
 
   toolSpecToDerivation = toolSpec:


### PR DESCRIPTION
ecdsa is insecure, see
https://github.com/tlsfuzzer/python-ecdsa/issues/352

For the libxml2 change, see
https://github.com/NixOS/nixpkgs/pull/421740