### PR TITLE
fix build on unstable nixpkgs by removing python3.10

### DIFF
--- a/pkgs/esp-idf/tools.nix
+++ b/pkgs/esp-idf/tools.nix
@@ -14,7 +14,6 @@
 , glibc
 , ncurses5
 , python3
-, python310
 , python311
 , python312
 , libxml2_13
@@ -38,7 +37,6 @@ let
     libusb1
     udev
     python3
-    python310
     python311
     python312
     libxml2_13
@@ -104,6 +102,7 @@ let
       # Configure autoPatchelfHook to ignore missing Python libraries that aren't available
       autoPatchelfIgnoreMissingDeps = [
         "libpython3.13.so.1.0"
+        "libpython3.10.so.1.0"
         "libpython3.9.so.1.0"
         "libpython3.8.so.1.0"
         "libpython3.7.so.1.0"


### PR DESCRIPTION
fixes #120
I don't know if this has any unintended side-effects, but all the checks pass for me on x86_64 when using unstable.